### PR TITLE
fix(rag-trace): 修复 Request 参数因未声明泛型导致 selectPage 类型校验阻断引发 500 报错的问题

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceQueryServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceQueryServiceImpl.java
@@ -71,7 +71,8 @@ public class RagTraceQueryServiceImpl implements RagTraceQueryService {
             wrapper.eq(RagTraceRunDO::getStatus, request.getStatus());
         }
 
-        IPage<RagTraceRunDO> pageResult = runMapper.selectPage(request, wrapper);
+        IPage<RagTraceRunDO> pageParam = new com.baomidou.mybatisplus.extension.plugins.pagination.Page<>(request.getCurrent(), request.getSize());
+        IPage<RagTraceRunDO> pageResult = runMapper.selectPage(pageParam, wrapper);
         Map<String, String> usernameMap = loadUsernameMap(pageResult.getRecords());
         return pageResult.convert(run -> toRunVO(run, usernameMap));
     }


### PR DESCRIPTION
### 🐛 Bug 描述
在访问管理后台“日志追踪”列表接口 `/api/ragent/rag/traces/runs` 时，服务端抛出 500 异常，错误日志如下：
> `java.lang.Error: Unresolved compilation problem: The method selectPage(P, Wrapper<RagTraceRunDO>) in the type BaseMapper<RagTraceRunDO> is not applicable for the arguments (RagTraceRunPageRequest, LambdaQueryWrapper<RagTraceRunDO>)`

该错误使得前端日志追踪列表一直无法正常渲染分页数据。

### 🔍 根本原因 (Root Cause)
在 RagTraceQueryServiceImpl.java 第 74 行调用分页查询时：
`IPage<RagTraceRunDO> pageResult = runMapper.selectPage(request, wrapper);`
由于入参 request 的实际类型 RagTraceRunPageRequest 只是继承了 MyBatis-Plus 的 Page 类而**没有声明具体的实体泛型**（即触发了 Java Generics 的裸类型 Raw Type 陷阱，被视为了 Page<Object>）。
而 BaseMapper<RagTraceRunDO>.selectPage() 的方法签名严格要求第一个参数必须实现了 IPage<RagTraceRunDO>，导致出现 Java 强类型环境下的泛型推断阻断，引发了运行时的未决编译异常。

### 🛠️ 修复方案
在 Service 层的实现逻辑中，放弃将没有实体泛型的 Request 对象直接塞给 Mapper。
改为：基于 Request 的 Current 和 Size，当场显式 new 一个让 Java 1.8 能够正确进行菱形推断（Diamond Operator）的新 Page 容器，以满足泛型强约束。

**修改前的代码：**
`IPage<RagTraceRunDO> pageResult = runMapper.selectPage(request, wrapper);`

**修改后的代码：**
`IPage<RagTraceRunDO> pageParam = new com.baomidou.mybatisplus.extension.plugins.pagination.Page<>(request.getCurrent(), request.getSize());`
`IPage<RagTraceRunDO> pageResult = runMapper.selectPage(pageParam, wrapper);`

此方案在避免了修改 Controller 层 Request 请求体父类引起潜在耦合风险的同时，完美满足 MyBatis-Plus BaseMapper 的强泛型校验契约，Bug 修复生效。
