### PR TITLE
fix(code): await code

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -91,7 +91,7 @@ export function ChatInput() {
                   return;
                 }
                 event.preventDefault();
-                handleSubmit();
+                await handleSubmit();
               }
             }}
             aria-label="聊天输入框"


### PR DESCRIPTION
Saw something in frontend/src/components/chat/ChatInput.tsx that seemed worth flagging, though you know the codebase better than I do. The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.