### PR TITLE
fix(KnowledgeDocumentServiceImpl):修复了修改文档信息时chunk_config格式报错问题

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/knowledge/service/impl/KnowledgeDocumentServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/knowledge/service/impl/KnowledgeDocumentServiceImpl.java
@@ -456,7 +456,7 @@ public class KnowledgeDocumentServiceImpl implements KnowledgeDocumentService {
                 ChunkingMode chunkingMode = ChunkingMode.fromValue(requestParam.getChunkStrategy());
                 String chunkConfig = validateAndNormalizeChunkConfig(chunkingMode, requestParam.getChunkConfig());
                 updateWrapper.set(KnowledgeDocumentDO::getChunkStrategy, chunkingMode.getValue());
-                updateWrapper.set(KnowledgeDocumentDO::getChunkConfig, chunkConfig);
+                updateWrapper.setSql("chunk_config = CAST({0} AS jsonb)", chunkConfig);
                 updateWrapper.set(KnowledgeDocumentDO::getPipelineId, null);
             } else {
                 if (!StringUtils.hasText(requestParam.getPipelineId())) {


### PR DESCRIPTION
### 变更说明
修复 `KnowledgeDocumentServiceImpl#update` 在修改文档信息时，更新 `chunk_config` 字段导致 PostgreSQL 报错的问题。
### 问题现象
在调用文档更新接口时，如果本次更新涉及 `chunk_config` 字段，会出现以下异常：
```text
Cause: org.postgresql.util.PSQLException: ERROR: column "chunk_config" is of type jsonb but expression is of type character varying
```

### 原因分析
t_knowledge_document.chunk_config 字段在 PostgreSQL 中的类型为 jsonb。

原实现中，在 KnowledgeDocumentServiceImpl#update 里通过 LambdaUpdateWrapper.set(...) 直接更新 chunkConfig，该写法在当前场景下会将参数按普通字符串进行绑定，导致 PostgreSQL 认为传入值类型为 character varying，从而与 jsonb 列类型不匹配并报错。

### 修复内容
将 chunk_config 的更新方式由普通 set(...) 调整为显式转换为 jsonb 的 SQL 写法：

修复前：直接按字符串更新 chunkConfig
修复后：使用 CAST(... AS jsonb) 写入 chunk_config
这样可以确保 PostgreSQL 在更新时按 jsonb 类型处理该字段，避免类型不匹配异常。

### 验证情况
已确认以下场景符合预期：
1.修改文档名称等普通信息时不受影响
2.修改 processMode=chunk 相关配置时，chunk_config 可正常更新
3.不再出现 jsonb 与 character varying 类型不匹配异常

### 备注
排查当前代码后，暂未发现其他 jsonb 字段存在相同的 wrapper set(...) 更新风险点。