### PR TITLE
feat: 添加 API Key 脱敏显示功能

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/controller/RAGSettingsController.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/controller/RAGSettingsController.java
@@ -30,6 +30,7 @@ import com.nageoffer.ai.ragent.rag.controller.vo.SystemSettingsVO.DefaultSetting
 import com.nageoffer.ai.ragent.rag.controller.vo.SystemSettingsVO.MemorySettings;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -111,7 +112,7 @@ public class RAGSettingsController {
         if (props.getProviders() != null) {
             props.getProviders().forEach((k, v) -> providers.put(k, AISettings.ProviderConfig.builder()
                     .url(v.getUrl())
-                    .apiKey(v.getApiKey())
+                    .apiKey(maskApiKey(v.getApiKey()))
                     .endpoints(v.getEndpoints())
                     .build()));
         }
@@ -151,5 +152,16 @@ public class RAGSettingsController {
                                 .build())
                         .collect(Collectors.toList()))
                 .build();
+    }
+
+    private String maskApiKey(String apiKey) {
+        if (!StringUtils.hasText(apiKey)) {
+            return null;
+        }
+        String trimmed = apiKey.trim();
+        if (trimmed.length() <= 10) {
+            return "******";
+        }
+        return trimmed.substring(0, 6) + "***" + trimmed.substring(trimmed.length() - 4);
     }
 }

--- a/frontend/src/pages/admin/settings/SystemSettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/SystemSettingsPage.tsx
@@ -22,6 +22,12 @@ function InfoItem({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
+function maskApiKey(apiKey?: string | null): string {
+  if (!apiKey) return "-";
+  if (apiKey.length <= 10) return "******";
+  return `${apiKey.slice(0, 6)}***${apiKey.slice(-4)}`;
+}
+
 export function SystemSettingsPage() {
   const [settings, setSettings] = useState<SystemSettings | null>(null);
   const [loading, setLoading] = useState(true);
@@ -141,7 +147,7 @@ export function SystemSettingsPage() {
                 <TableRow key={name}>
                   <TableCell className="font-medium">{name}</TableCell>
                   <TableCell>{provider.url}</TableCell>
-                  <TableCell>{provider.apiKey ? provider.apiKey : "-"}</TableCell>
+                  <TableCell>{maskApiKey(provider.apiKey)}</TableCell>
                   <TableCell>
                     <div className="space-y-1 text-xs text-muted-foreground">
                       {Object.entries(provider.endpoints).map(([key, value]) => (


### PR DESCRIPTION
**问题**
发现前端http://localhost:5177/api/ragent/rag/settings请求会明文展示后端的api key

**修改**
- 后端添加 maskApiKey 方法对 API Key 进行脱敏处理
- 前端添加 maskApiKey 函数显示脱敏后的 API Key
- 防止在系统设置页面暴露完整的 API 密钥"