### PR TITLE
fix: add missing Guava version and jspecify dependency

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -34,6 +34,13 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>33.4.0-jre</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
@
## Summary
- Fix two compilation-blocking issues in `framework/pom.xml` that prevent `mvn clean install` on any machine

## Changes
1. **Add Guava version** (`33.4.0-jre`) — dependency was declared without `<version>`, Maven refuses to resolve it
2. **Add jspecify dependency** (`1.0.0`) — `ApplicationContextHolder.java` imports `@NonNull` from `org.jspecify.annotations`, but this optional transitive dep of Guava is not resolved automatically

## Verification
```
[INFO] Reactor Summary for ragent-ai 0.0.1-SNAPSHOT:
[INFO] ragent-ai .......................................... SUCCESS
[INFO] framework .......................................... SUCCESS
[INFO] infra-ai ........................................... SUCCESS
[INFO] bootstrap .......................................... SUCCESS
[INFO] mcp-server ......................................... SUCCESS
[INFO] BUILD SUCCESS
```
- Java 17, Windows 11
- All 5 modules compile successfully after fix

## Before / After
| Before | After |
|:---|:---|
| `mvn compile` fails: `dependencies.dependency.version for guava is missing` | Passes |
| `mvn compile` fails: `找不到org.jspecify.annotations包` | Passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@