### PR TITLE
fix(trace): TTL 深拷贝修复 + 前端 trace 树显示修复

### DIFF
--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/trace/RagTraceContextConcurrencyTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/trace/RagTraceContextConcurrencyTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.trace;
+
+import com.alibaba.ttl.threadpool.TtlExecutors;
+import com.nageoffer.ai.ragent.framework.trace.RagTraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * 复现 RagTraceContext 中 NODE_STACK (TransmittableThreadLocal<Deque>)
+ * 在并发场景下因浅拷贝导致的 depth 不一致
+ * <p>
+ * 模拟场景：intent-resolve 下两个子问题并行执行，
+ * 每个子问题进入 llm-chat-routing → bailian-chat 两层嵌套。
+ * <p>
+ * 期望行为：每个子线程的 depth 链路应该独立，bailian-chat 层的 depth 应一致为 2。
+ * 实际行为（浅拷贝 bug）：多个子线程共享同一个 Deque 实例，depth 会互相干扰。
+ */
+@DisplayName("RagTraceContext TTL 浅拷贝并发 Bug 复现")
+class RagTraceContextConcurrencyTest {
+
+    /**
+     * 使用 TtlExecutors 包装线程池，与生产环境 ThreadPoolExecutorConfig 一致
+     */
+    private final Executor ttlExecutor = TtlExecutors.getTtlExecutor(
+            Executors.newFixedThreadPool(4));
+
+    @AfterEach
+    void cleanup() {
+        RagTraceContext.clear();
+    }
+
+    /**
+     * 复现 Bug：多子问题并行时 bailian-chat 层的 depth 不一致
+     * 前提: RagTraceContext 中 NODE_STACK 为原来的浅拷贝实现
+     * <p>
+     * 模拟 intent-resolve 的执行流程：
+     * 父线程: setTraceId → pushNode(intent-resolve)
+     * 子线程A: pushNode(routing_A) → 读 depth → pushNode(chat_A) → 读 depth → pop → pop
+     * 子线程B: pushNode(routing_B) → 读 depth → pushNode(chat_B) → 读 depth → pop → pop
+     * <p>
+     * 浅拷贝时子线程共享同一个 Deque，push/pop 互相干扰，
+     * 导致 chat 层读到的 depth 不总是 2。
+     */
+    @RepeatedTest(5)
+    @DisplayName("Bug1: 多子问题 depth 不一致")
+    void shouldHaveConsistentDepth_butShallowCopyCauseDrift() {
+        // ---- 模拟父线程：进入 intent-resolve（depth=0 时 push，之后 depth=1）----
+        RagTraceContext.setTraceId("test-trace-001");
+        String intentNodeId = "node-intent-resolve";
+        RagTraceContext.pushNode(intentNodeId);
+        assertEquals(1, RagTraceContext.depth(), "intent-resolve push 后 depth 应为 1");
+
+        int subQuestionCount = 2;
+        CountDownLatch startGate = new CountDownLatch(1);
+        CopyOnWriteArrayList<Integer> routingDepths = new CopyOnWriteArrayList<>();
+        CopyOnWriteArrayList<Integer> chatDepths = new CopyOnWriteArrayList<>();
+
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+        for (int i = 0; i < subQuestionCount; i++) {
+            final int index = i;
+            tasks.add(CompletableFuture.runAsync(() -> {
+                try {
+                    startGate.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+
+                // ---- 模拟 llm-chat-routing 层 ----
+                int depthBeforeRouting = RagTraceContext.depth();
+                routingDepths.add(depthBeforeRouting);
+                String routingNodeId = "node-routing-" + index;
+                RagTraceContext.pushNode(routingNodeId);
+
+                // 模拟一点处理时间，增加交错概率
+                sleepQuietly(5);
+
+                // ---- 模拟 bailian-chat 层 ----
+                int depthBeforeChat = RagTraceContext.depth();
+                chatDepths.add(depthBeforeChat);
+                String chatNodeId = "node-chat-" + index;
+                RagTraceContext.pushNode(chatNodeId);
+
+                sleepQuietly(10); // 模拟 LLM 调用
+
+                // ---- 退出 bailian-chat ----
+                RagTraceContext.popNode();
+                // ---- 退出 llm-chat-routing ----
+                RagTraceContext.popNode();
+
+            }, ttlExecutor));
+        }
+
+        // 释放所有子线程
+        startGate.countDown();
+        CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
+
+        // ---- 断言：如果 TTL 做了深拷贝，每个子线程的 depth 应该完全独立 ----
+        // routing 层 depth 应全部为 1（intent-resolve 栈里 1 个元素）
+        // chat 层 depth 应全部为 2（intent-resolve + routing 栈里 2 个元素）
+
+        System.out.println("routing depths: " + routingDepths);
+        System.out.println("chat depths:    " + chatDepths);
+
+        boolean allRoutingCorrect = routingDepths.stream().allMatch(d -> d == 1);
+        boolean allChatCorrect = chatDepths.stream().allMatch(d -> d == 2);
+
+        if (!allRoutingCorrect || !allChatCorrect) {
+            StringBuilder msg = new StringBuilder("[BUG 复现成功] depth 偏离预期!\n");
+            if (!allRoutingCorrect) {
+                msg.append("  routing depth: 期望全部=1, 实际=").append(routingDepths).append("\n");
+            }
+            if (!allChatCorrect) {
+                msg.append("  chat depth: 期望全部=2, 实际=").append(chatDepths).append("\n");
+            }
+            System.err.print(msg);
+            fail(msg.toString());
+        }
+    }
+
+
+    private void sleepQuietly(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/trace/RagTraceContext.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/trace/RagTraceContext.java
@@ -30,7 +30,13 @@ public final class RagTraceContext {
 
     private static final TransmittableThreadLocal<String> TRACE_ID = new TransmittableThreadLocal<>();
     private static final TransmittableThreadLocal<String> TASK_ID = new TransmittableThreadLocal<>();
-    private static final TransmittableThreadLocal<Deque<String>> NODE_STACK = new TransmittableThreadLocal<>();
+    private static final TransmittableThreadLocal<Deque<String>> NODE_STACK = new TransmittableThreadLocal<>() {
+        @Override
+        public Deque<String> copy(Deque<String> parentValue) {
+            if (parentValue == null) return null;
+            return new ArrayDeque<>(parentValue);
+        }
+    };
 
     private RagTraceContext() {
     }

--- a/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
+++ b/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
@@ -270,18 +270,62 @@ export function RagTraceDetailPage() {
     const runDuration = Number(selectedRun?.durationMs ?? 0);
     const windowDuration = Math.max(runDuration > 0 ? runDuration : maxEnd - baseStart, 1);
 
-    const rows = normalized
-        .sort((a, b) => a.startTs - b.startTs || a.depthValue - b.depthValue)
-        .map((node) => {
-          const offsetMs = node.startTs > 0 ? Math.max(0, node.startTs - baseStart) : 0;
-          const leftPercent = clamp((offsetMs / windowDuration) * 100, 0, 99.2);
-          const widthPercent = clamp(
-              (Math.max(node.resolvedDurationMs, 1) / windowDuration) * 100,
-              0.8,
-              100 - leftPercent
-          );
-          return { ...node, offsetMs, leftPercent, widthPercent };
-        });
+    // 使用 parentNodeId 构建树，DFS 遍历确定显示顺序，这样每个子节点紧跟在其父节点之后
+    const childrenMap = new Map<string, typeof normalized>();
+    const roots: typeof normalized = [];
+
+    for (const node of normalized) {
+      const parentId = node.parentNodeId;
+      if (!parentId) {
+        roots.push(node);
+      } else {
+        let siblings = childrenMap.get(parentId);
+        if (!siblings) {
+          siblings = [];
+          childrenMap.set(parentId, siblings);
+        }
+        siblings.push(node);
+      }
+    }
+
+    const sortSiblings = (list: typeof normalized) =>
+        list.sort((a, b) => a.startTs - b.startTs || a.depthValue - b.depthValue);
+
+    sortSiblings(roots);
+    for (const siblings of childrenMap.values()) {
+      sortSiblings(siblings);
+    }
+
+    const ordered: typeof normalized = [];
+    const stack = [...roots].reverse();
+    while (stack.length > 0) {
+      const node = stack.pop()!;
+      ordered.push(node);
+      const children = childrenMap.get(node.nodeId);
+      if (children) {
+        for (let i = children.length - 1; i >= 0; i--) {
+          stack.push(children[i]);
+        }
+      }
+    }
+
+    const orderedSet = new Set(ordered.map(n => n.nodeId));
+    for (const node of normalized) {
+      if (!orderedSet.has(node.nodeId)) {
+        ordered.push(node);
+      }
+    }
+
+    const rows = ordered.map((node) => {
+      const offsetMs = node.startTs > 0 ? Math.max(0, node.startTs - baseStart) : 0;
+      const leftPercent = clamp((offsetMs / windowDuration) * 100, 0, 99.2);
+      const widthPercent = clamp(
+          (Math.max(node.resolvedDurationMs, 1) / windowDuration) * 100,
+          0.8,
+          100 - leftPercent
+      );
+      return { ...node, offsetMs, leftPercent, widthPercent };
+    });
 
     return { totalWindowMs: windowDuration, nodes: rows };
   }, [detail?.nodes, selectedRun?.durationMs]);


### PR DESCRIPTION
## Summary

- 修复 `RagTraceContext` 中 `TransmittableThreadLocal<Deque<String>>` 共享状态导致的并发 trace 污染问题
- 修复 trace 详情页扁平排序导致父子节点被打散的树形渲染问题

---

## Problem

### 1. 后端：`NODE_STACK` 并发污染问题

`RagTraceAspect` 使用 `RagTraceContext.NODE_STACK`
（`TransmittableThreadLocal<Deque<String>>`）维护 trace 的调用深度和父子关系。

此前 TTL 默认 `copy()` 行为仅复制引用，导致多个子线程共享同一个 `ArrayDeque` 实例。

在并发场景下，不同子线程会同时操作同一份栈数据，导致：

- `depth()` 值异常
- `parentNodeId` 指向错误
- `ArrayDeque` 并发 `push/pop` 存在线程安全风险

实际表现包括：
<img width="3601" height="1238" alt="image" src="https://github.com/user-attachments/assets/aa6719bf-a1d7-42aa-b832-e18b96806f54" />


### 2. 前端：trace 树结构被扁平排序打散

trace 详情页此前基于 `startTs + depth` 做全局扁平排序。

但 trace 节点本质是通过 `parentNodeId` 关联的树结构。

---

## Fix

### 后端

重写 `TransmittableThreadLocal.copy()`，为每个子线程创建独立的 deque 副本：

```java
private static final TransmittableThreadLocal<Deque<String>> NODE_STACK =
        new TransmittableThreadLocal<>() {
            @Override
            public Deque<String> copy(Deque<String> parentValue) {
                if (parentValue == null) {
                    return null;
                }
                return new ArrayDeque<>(parentValue);
            }
        };
```

确保每个子线程拥有独立的 trace 栈，避免共享状态污染。

### 前端

基于 `parentNodeId` 重建 trace 树并使用 DFS 展平：

- 使用 `childrenMap + roots` 构建树结构
- 同级节点按 `startTime` 排序
- 使用 DFS 保证子节点紧跟父节点显示
- 孤儿节点（父节点不存在）追加到末尾

修复后，多分支 trace 可以稳定保持正确层级结构。

---

## Test Plan

### 后端

新增 `RagTraceContextConcurrencyTest`

- 模拟多子问题并发执行
- 验证各子线程 `depth` 的一致性
- 使用 `@RepeatedTest(5)` 增加线程交错概率

### 前端

验证 trace 详情页：

- 父子节点保持连续显示
- 多分支结构层级正确
- 子节点不会再被其他分支打断