### PR TITLE
fix(trace): 前端 trace 详情页改用 parentNodeId DFS 展开替代平坦排序

### DIFF
--- a/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
+++ b/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
@@ -456,9 +456,55 @@ export function RagTraceDetailPage() {
         }
         : null;
 
+    // 使用 parentNodeId 构建树，DFS 遍历确定显示顺序
+    const childrenMap = new Map<string, typeof normalized>();
+    const treeRoots: typeof normalized = [];
+
+    for (const node of normalized) {
+      const parentId = node.parentNodeId;
+      if (!parentId) {
+        treeRoots.push(node);
+      } else {
+        let siblings = childrenMap.get(parentId);
+        if (!siblings) {
+          siblings = [];
+          childrenMap.set(parentId, siblings);
+        }
+        siblings.push(node);
+      }
+    }
+
+    const sortSiblings = (list: typeof normalized) =>
+        list.sort((a, b) => a.startTs - b.startTs || a.depthValue - b.depthValue);
+
+    sortSiblings(treeRoots);
+    for (const siblings of childrenMap.values()) {
+      sortSiblings(siblings);
+    }
+
+    const ordered: typeof normalized = [];
+    const dfsStack = [...treeRoots].reverse();
+    while (dfsStack.length > 0) {
+      const node = dfsStack.pop()!;
+      ordered.push(node);
+      const children = childrenMap.get(node.nodeId);
+      if (children) {
+        for (let i = children.length - 1; i >= 0; i--) {
+          dfsStack.push(children[i]);
+        }
+      }
+    }
+
+    const orderedSet = new Set(ordered.map(n => n.nodeId));
+    for (const node of normalized) {
+      if (!orderedSet.has(node.nodeId)) {
+        ordered.push(node);
+      }
+    }
+
     const rows = [
       ...(rootRow ? [rootRow] : []),
-      ...normalized.sort((a, b) => a.startTs - b.startTs || a.depthValue - b.depthValue)
+      ...ordered
     ].map((node) => {
       const offsetMs = node.startTs > 0 ? Math.max(0, node.startTs - baseStart) : 0;
       const leftPercent = clamp((offsetMs / windowDuration) * 100, 0, 99.2);


### PR DESCRIPTION
## Summary

  - 将 trace 详情页的节点排序从 `startTs + depth` 平坦排序改为按 `parentNodeId` 建树 + DFS 遍历

  ## Problem

前端 trace 页面节点排序使用平坦排序：

  ```ts
  normalized.sort((a, b) => a.startTs - b.startTs || a.depthValue - b.depthValue)
```

  多子问题并发检索场景下（RetrievalEngine 用 CompletableFuture.supplyAsync 并发执行），不同分支的节点时间戳交错，导致父子节点被打散：

<img width="3840" height="2159" alt="image" src="https://github.com/user-attachments/assets/ff806752-897d-49eb-8c71-70a299c9885a" />

<img width="3418" height="1977" alt="image" src="https://github.com/user-attachments/assets/fb9e999b-a3f7-4d86-8982-3f0652d75ae5" />


 ## Fix

  基于 parentNodeId 构建树结构，同级节点按 startTs 排序，DFS 遍历生成显示顺序。孤儿节点追加到末尾。

## Test Plan

  - 发送会被拆分为多个子问题的复合问题
  - 进入管理后台 trace 详情页，验证各分支子节点紧跟其父节点显示

<img width="3418" height="1977" alt="image" src="https://github.com/user-attachments/assets/3ee6a564-faf8-4232-8759-4a526be1ec18" />
