### PR TITLE
fix(trace): LLM_TTFT 父节点错误 + 前端未映射 ERROR/CANCELLED 状态

### DIFF
--- a/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
+++ b/frontend/src/pages/admin/traces/RagTraceDetailPage.tsx
@@ -59,18 +59,20 @@ const copyToClipboard = (text: string, label: string) => {
 
 // ============ 状态颜色 ============
 
-type StatusType = "success" | "failed" | "running" | "default";
+type StatusType = "success" | "failed" | "error" | "running" | "cancelled" | "default";
 
 const STATUS_COLORS: Record<StatusType, { dot: string; bar: string }> = {
   success: { dot: "bg-emerald-500", bar: "bg-emerald-400" },
   failed: { dot: "bg-red-500", bar: "bg-red-400" },
+  error: { dot: "bg-red-500", bar: "bg-red-400" },
   running: { dot: "bg-amber-500", bar: "bg-amber-400" },
+  cancelled: { dot: "bg-slate-400", bar: "bg-slate-300" },
   default: { dot: "bg-slate-300", bar: "bg-slate-300" }
 };
 
 const getStatusColors = (status?: string | null) => {
-  const normalized = normalizeStatus(status) as StatusType | null;
-  return STATUS_COLORS[normalized || "default"];
+  const normalized = normalizeStatus(status) as StatusType;
+  return STATUS_COLORS[normalized] ?? STATUS_COLORS.default;
 };
 
 // ============ 子组件 ============

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
@@ -144,25 +144,43 @@ public abstract class AbstractOpenAIStyleChatClient implements ChatClient {
 
         // 在调用线程开 stream span，使后续 first-packet 子节点能正确归属父节点；
         // 该 span 由 SSE 终态（onComplete / onError）或 cancel 时收尾，记录真实端到端耗时
+        // 注意：此处不 detach，由调用方（RoutingLLMService）在 awaitFirstPacket 之后调 handle.detach()
         StreamSpan span = streamTraceSupport.beginStreamNode(provider() + "-stream-chat", "LLM_PROVIDER");
-        StreamSpanCallback wrappedCallback;
-        try {
-            wrappedCallback = new StreamSpanCallback(callback, span);
-            StreamCancellationHandle inner = StreamAsyncExecutor.submit(
-                    modelStreamExecutor,
-                    call,
-                    wrappedCallback,
-                    cancelled -> doStream(call, wrappedCallback, cancelled, reasoningEnabled)
-            );
-            return () -> {
-                try {
-                    inner.cancel();
-                } finally {
-                    wrappedCallback.onCancel();
-                }
-            };
-        } finally {
-            // 同步部分结束：把节点从当前线程的 NODE_STACK 弹出，避免污染兄弟节点的父节点链
+        StreamSpanCallback wrappedCallback = new StreamSpanCallback(callback, span);
+        StreamCancellationHandle inner = StreamAsyncExecutor.submit(
+                modelStreamExecutor,
+                call,
+                wrappedCallback,
+                cancelled -> doStream(call, wrappedCallback, cancelled, reasoningEnabled)
+        );
+        return new StreamChatHandle(() -> {
+            try {
+                inner.cancel();
+            } finally {
+                wrappedCallback.onCancel();
+            }
+        }, span);
+    }
+
+    /**
+     * 携带 StreamSpan 的取消句柄，供调用方在首包探测完成后调 detach() 弹出 NODE_STACK
+     */
+    public static final class StreamChatHandle implements StreamCancellationHandle {
+        private final StreamCancellationHandle delegate;
+        private final StreamSpan span;
+
+        public StreamChatHandle(StreamCancellationHandle delegate, StreamSpan span) {
+            this.delegate = delegate;
+            this.span = span;
+        }
+
+        @Override
+        public void cancel() {
+            delegate.cancel();
+        }
+
+        @Override
+        public void detach() {
             span.detach();
         }
     }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMService.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMService.java
@@ -138,7 +138,14 @@ public class RoutingLLMService implements LLMService {
                 continue;
             }
 
-            ProbeStreamBridge.ProbeResult result = awaitFirstPacket(bridge, handle, callback);
+            ProbeStreamBridge.ProbeResult result;
+            try {
+                result = awaitFirstPacket(bridge, handle, callback);
+            } finally {
+                // 首包探测完成后（无论成功失败）弹出 LLM_PROVIDER 节点，
+                // 确保 TTFT 节点已正确归属到 provider 下
+                handle.detach();
+            }
 
             if (result.isSuccess()) {
                 healthStore.markSuccess(target.id());

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/StreamCancellationHandle.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/StreamCancellationHandle.java
@@ -45,4 +45,12 @@ public interface StreamCancellationHandle {
      * - 调用后应该不会再继续产生 onContent() 回调
      */
     void cancel();
+
+    /**
+     * 将该 handle 关联的 trace 节点从当前线程的 NODE_STACK 弹出
+     * <p>
+     * 仅由内部实现覆写（如 StreamChatHandle），用于延迟 detach 跨线程 span，
+     * 使首包探测等同步子节点能正确归属到该 provider 节点下
+     */
+    default void detach() {}
 }


### PR DESCRIPTION
 ## Summary

  - 修复 `llm-first-packet` (LLM_TTFT) 节点的 `parentNodeId` 错误指向 `llm-stream-routing`，而非具体的 provider 流式节点
  - 修复前端 trace 详情页在故障转移场景下因未映射 `ERROR`/`CANCELLED` 状态导致渲染崩溃

  ## Problem

  ### 后端：LLM_TTFT 父节点错误

  `AbstractOpenAIStyleChatClient.doStreamChat()` 在 finally 块中调用 `span.detach()` 弹出 LLM_PROVIDER 节点，但 `RoutingLLMService` 的
  `awaitFirstPacket()`（`@RagTraceNode("llm-first-packet")`）在 detach 之后才执行，导致 TTFT 节点的 parentNodeId 错误地指向 `llm-stream-routing`：

  实际 trace 树：
```
  llm-stream-routing
  ├── bailian-stream-chat (LLM_PROVIDER)
  └── llm-first-packet (LLM_TTFT)
```

<img width="3418" height="1977" alt="image" src="https://github.com/user-attachments/assets/46e7915b-14ae-4ed0-ba2e-54e3d8973a4a" />

```
  期望 trace 树：
  llm-stream-routing
  └── bailian-stream-chat (LLM_PROVIDER)
      └── llm-first-packet (LLM_TTFT)
```

<img width="3418" height="1977" alt="image" src="https://github.com/user-attachments/assets/abc32d86-64e6-45f4-bde7-7d936520982a" />

<img width="3418" height="1977" alt="image" src="https://github.com/user-attachments/assets/d253e783-835c-4dd8-90bf-e27155a071f1" />

  ### 前端：ERROR/CANCELLED 状态未映射

  `STATUS_COLORS` 只映射了 `success`/`failed`/`running`/`default`，故障转移时 provider 节点状态为 `CANCELLED` 或 `ERROR`，访问时导致页面崩溃。

  ## Fix

  ### 后端

  - `doStreamChat` 不再在 finally 中 detach，改为通过 `StreamChatHandle` 将 span 携带返回
  - `StreamCancellationHandle` 新增 `default void detach() {}` 方法，向后兼容
  - `RoutingLLMService` 在 `awaitFirstPacket` 之后调 `handle.detach()`，确保 TTFT 记录时 LLM_PROVIDER 节点仍在栈上
  - 故障转移场景：每次循环 try-finally 保证无论成功失败都 detach，避免影响下一个 provider 的父节点链


  ### 前端

  - `STATUS_COLORS` 补充 `error`（红色）和 `cancelled`（灰色）状态映射
  - `getStatusColors` 增加 `?? STATUS_COLORS.default` 兜底

  ## Test Plan

  - [ ] 正常对话：验证 `llm-first-packet` 的 parentNodeId 指向具体 provider 流式节点
  - [ ] 故障转移：模拟首包超时触发 provider 切换，验证 fallback 后 trace 树结构正确
  - [ ] 前端 trace 详情页：验证 ERROR/CANCELLED 状态节点正常显示，不再崩溃