### PR TITLE
feat(rag): 新增 You.com 联网检索通道与 youcom_search MCP 工具

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/config/SearchChannelProperties.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/config/SearchChannelProperties.java
@@ -61,6 +61,11 @@ public class SearchChannelProperties {
          * 关键词检索配置
          */
         private Keyword keyword = new Keyword();
+
+        /**
+         * 联网检索配置（You.com Search）
+         */
+        private WebSearch webSearch = new WebSearch();
     }
 
     @Data
@@ -145,6 +150,39 @@ public class SearchChannelProperties {
          * 关键词召回更多候选，后续通过融合与 Rerank 筛选
          */
         private int topKMultiplier = 2;
+    }
+
+    @Data
+    public static class WebSearch {
+
+        /**
+         * 是否启用
+         * 默认关闭；开启后还需配置 api-key（或环境变量 YDC_API_KEY），两者缺一通道不生效
+         */
+        private boolean enabled = false;
+
+        /**
+         * 返回结果数量
+         * 默认 5，上限 20（超出会被通道内截断）
+         */
+        private int count = 5;
+
+        /**
+         * 请求超时（秒）
+         */
+        private int timeoutSeconds = 10;
+
+        /**
+         * You.com Search API Key
+         * 建议留空，此时回退读取环境变量 YDC_API_KEY，避免密钥落入配置文件
+         */
+        private String apiKey = "";
+
+        /**
+         * You.com Search API 地址
+         * 一般无需修改，测试时可指向本地 stub
+         */
+        private String apiUrl = "https://ydc-index.io/v1/search";
     }
 
     @Data

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/SearchChannelType.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/SearchChannelType.java
@@ -47,6 +47,12 @@ public enum SearchChannelType {
     GRAPH,
 
     /**
+     * 联网检索
+     * 基于外部 Web 搜索 API（如 You.com Search）的实时网络召回，与本地知识库通道互补
+     */
+    WEB_SEARCH,
+
+    /**
      * 混合检索
      * 结合多种检索策略
      */

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannel.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannel.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieve.channel;
+
+import cn.hutool.core.util.StrUtil;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * You.com 联网检索通道
+ * <p>
+ * 基于 You.com Search API 的实时网络召回，与本地知识库通道互补：
+ * 擅长时效性问题、公开资讯等本地知识库覆盖不到的内容
+ * <p>
+ * 启用条件（缺一不可）：
+ * - rag.search.channels.web-search.enabled = true
+ * - 可解析到 API Key（优先取配置 api-key，为空回退环境变量 YDC_API_KEY）
+ * <p>
+ * 优先级排在所有本地通道（意图定向 1 / 关键词 5 / 向量全局 10）之后；
+ * 任何失败（网络异常、非 2xx、响应格式异常、超时）只记录 warn 日志并返回空结果，
+ * 绝不让联网检索故障影响本地检索链路
+ */
+@Slf4j
+@Component
+public class YouComWebSearchChannel implements SearchChannel {
+
+    /**
+     * API Key 环境变量名（团队约定，勿改）
+     */
+    private static final String ENV_API_KEY = "YDC_API_KEY";
+
+    /**
+     * 单次检索返回结果数量上限
+     */
+    private static final int MAX_COUNT = 20;
+
+    /**
+     * 结果数量默认值（配置非法时兜底）
+     */
+    private static final int DEFAULT_COUNT = 5;
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final SearchChannelProperties properties;
+
+    public YouComWebSearchChannel(@Qualifier("syncHttpClient") OkHttpClient httpClient,
+                                  ObjectMapper objectMapper,
+                                  SearchChannelProperties properties) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+    }
+
+    @Override
+    public String getName() {
+        return "YouComWebSearch";
+    }
+
+    @Override
+    public int getPriority() {
+        return 20;  // 联网检索排在所有本地通道之后
+    }
+
+    @Override
+    public SearchChannelType getType() {
+        return SearchChannelType.WEB_SEARCH;
+    }
+
+    @Override
+    public boolean isEnabled(SearchContext context) {
+        SearchChannelProperties.WebSearch config = properties.getChannels().getWebSearch();
+        return config.isEnabled() && StrUtil.isNotBlank(resolveApiKey());
+    }
+
+    @Override
+    public SearchChannelResult search(SearchContext context) {
+        long startTime = System.currentTimeMillis();
+        try {
+            String query = context.getMainQuestion();
+            if (StrUtil.isBlank(query)) {
+                log.info("You.com 联网检索问题为空，跳过");
+                return emptyResult(startTime);
+            }
+
+            SearchChannelProperties.WebSearch config = properties.getChannels().getWebSearch();
+            HttpUrl httpUrl = HttpUrl.parse(config.getApiUrl());
+            if (httpUrl == null) {
+                log.warn("You.com 联网检索 api-url 配置非法：{}，返回空结果", config.getApiUrl());
+                return emptyResult(startTime);
+            }
+
+            Request request = new Request.Builder()
+                    .url(httpUrl.newBuilder()
+                            .addQueryParameter("query", query)
+                            .addQueryParameter("count", String.valueOf(resolveCount(config)))
+                            .build())
+                    .header("X-API-Key", resolveApiKey())
+                    .get()
+                    .build();
+
+            // 按通道配置收紧超时；newBuilder 复用连接池与线程池，代价可忽略
+            int timeoutSeconds = Math.max(1, config.getTimeoutSeconds());
+            OkHttpClient client = httpClient.newBuilder()
+                    .callTimeout(Duration.ofSeconds(timeoutSeconds))
+                    .readTimeout(Duration.ofSeconds(timeoutSeconds))
+                    .build();
+
+            List<RetrievedChunk> chunks;
+            try (Response response = client.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    // 401 鉴权失败 / 429 限流 / 5xx 服务端异常等统一降级为空结果（不打印 Key）
+                    log.warn("You.com 联网检索请求失败, code={}, 返回空结果", response.code());
+                    return emptyResult(startTime);
+                }
+                String body = response.body() != null ? response.body().string() : "";
+                chunks = parseChunks(body);
+            }
+
+            long latency = System.currentTimeMillis() - startTime;
+            log.info("You.com 联网检索完成，检索到 {} 个 Chunk，耗时 {}ms", chunks.size(), latency);
+
+            return SearchChannelResult.builder()
+                    .channelType(SearchChannelType.WEB_SEARCH)
+                    .channelName(getName())
+                    .chunks(chunks)
+                    .latencyMs(latency)
+                    .build();
+        } catch (Exception e) {
+            // 联网检索属于补充通道，任何异常（含超时、响应解析失败）都不允许向上抛出
+            log.warn("You.com 联网检索失败，降级为空结果: {}", e.getMessage());
+            return emptyResult(startTime);
+        }
+    }
+
+    /**
+     * 解析 You.com 响应为 RetrievedChunk 列表
+     * <p>
+     * 响应结构 {@code {"results": {"web": [...], "news": [...]}}}；
+     * news 可能缺失，每条结果中除 url/title/description/snippets 之外的字段均视为可选，防御式读取
+     */
+    private List<RetrievedChunk> parseChunks(String body) throws Exception {
+        JsonNode results = objectMapper.readTree(body).path("results");
+
+        List<JsonNode> items = new ArrayList<>();
+        collectItems(items, results.path("web"));
+        collectItems(items, results.path("news"));
+
+        // 初始分数决策：多通道场景下 FusionPostProcessor(RRF) 只按各通道内名次融合并覆盖分数，
+        // 去重处理器会对分数做数值比较（不能为 null），因此这里给出按名次递减的中性分数 1/(rank+1)，
+        // 仅表达通道内相对顺序，不与向量/BM25 分数做量纲比较；开启 Rerank 时最终由精排模型重新打分
+        List<RetrievedChunk> chunks = new ArrayList<>();
+        for (JsonNode item : items) {
+            RetrievedChunk chunk = toChunk(item, chunks.size());
+            if (chunk != null) {
+                chunks.add(chunk);
+            }
+        }
+        return chunks;
+    }
+
+    /**
+     * 单条结果映射
+     * <p>
+     * {@link RetrievedChunk} 仅有 id/text/score 三个字段（无 metadata 扩展位），
+     * 因此把标题与来源链接直接编排进 text，保证下游拼接 Prompt 时引用信息不丢失；
+     * id 取 url（联网结果的天然唯一键，供去重处理器使用）
+     */
+    private RetrievedChunk toChunk(JsonNode item, int rank) {
+        String url = item.path("url").asText("");
+        String title = item.path("title").asText("");
+        String description = item.path("description").asText("");
+
+        StringBuilder text = new StringBuilder();
+        if (StrUtil.isNotBlank(title)) {
+            text.append("【").append(title).append("】\n");
+        }
+        if (StrUtil.isNotBlank(description)) {
+            text.append(description).append('\n');
+        }
+        JsonNode snippets = item.path("snippets");
+        if (snippets.isArray()) {
+            for (JsonNode snippet : snippets) {
+                String s = snippet.asText("");
+                if (StrUtil.isNotBlank(s)) {
+                    text.append(s).append('\n');
+                }
+            }
+        }
+        if (StrUtil.isNotBlank(url)) {
+            text.append("来源: ").append(url);
+        }
+
+        String content = text.toString().trim();
+        if (StrUtil.isBlank(content)) {
+            return null;
+        }
+        return RetrievedChunk.builder()
+                .id(StrUtil.isNotBlank(url) ? url : null)
+                .text(content)
+                .score(1.0f / (rank + 1))
+                .build();
+    }
+
+    private void collectItems(List<JsonNode> items, JsonNode array) {
+        if (array != null && array.isArray()) {
+            array.forEach(items::add);
+        }
+    }
+
+    /**
+     * 解析结果数量：配置非法时回退默认值，超过上限截断
+     */
+    private int resolveCount(SearchChannelProperties.WebSearch config) {
+        int count = config.getCount() > 0 ? config.getCount() : DEFAULT_COUNT;
+        return Math.min(count, MAX_COUNT);
+    }
+
+    /**
+     * 解析 API Key：优先取配置 api-key，为空回退环境变量 YDC_API_KEY
+     */
+    private String resolveApiKey() {
+        String apiKey = properties.getChannels().getWebSearch().getApiKey();
+        return StrUtil.isNotBlank(apiKey) ? apiKey : readEnv(ENV_API_KEY);
+    }
+
+    /**
+     * 读取环境变量（可测试性：单元测试可覆盖此方法屏蔽真实环境）
+     */
+    protected String readEnv(String name) {
+        return System.getenv(name);
+    }
+
+    private SearchChannelResult emptyResult(long startTime) {
+        return SearchChannelResult.builder()
+                .channelType(SearchChannelType.WEB_SEARCH)
+                .channelName(getName())
+                .chunks(List.of())
+                .latencyMs(System.currentTimeMillis() - startTime)
+                .build();
+    }
+}

--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -113,6 +113,11 @@ rag:
         enabled: true
         mode: both
         top-k-multiplier: 2
+      web-search:  # You.com 联网检索通道，与本地知识库通道互补（结果实时来自网络）
+        enabled: false  # 默认关闭；开启后还需配置 api-key 或环境变量 YDC_API_KEY，两者缺一通道不生效
+        count: 5  # 返回结果数量，上限 20
+        timeout-seconds: 10  # 请求超时（秒），超时降级为空结果，不影响本地检索
+        api-key: ${YDC_API_KEY:}  # 默认读取环境变量 YDC_API_KEY（https://you.com/platform/api-keys 获取），不建议直接填写明文 Key
     fusion:
       strategy: rrf
       rrf-k: 60

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannelLiveTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannelLiveTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieve.channel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * You.com 联网检索通道真实 API 集成测试
+ * <p>
+ * 仅当环境变量 YDC_API_KEY 存在时运行（1 次真实调用），日常构建自动跳过
+ */
+@DisplayName("You.com 联网检索通道（真实 API）")
+@EnabledIfEnvironmentVariable(named = "YDC_API_KEY", matches = ".+")
+class YouComWebSearchChannelLiveTest {
+
+    @Test
+    @DisplayName("真实检索返回非空 Chunk，且带来源链接")
+    void liveSearchReturnsChunks() {
+        SearchChannelProperties properties = new SearchChannelProperties();
+        SearchChannelProperties.WebSearch webSearch = properties.getChannels().getWebSearch();
+        webSearch.setEnabled(true);
+        webSearch.setCount(3);
+        // api-key 留空 -> 回退环境变量 YDC_API_KEY
+
+        YouComWebSearchChannel channel = new YouComWebSearchChannel(
+                new OkHttpClient(), new ObjectMapper(), properties);
+
+        assertTrue(channel.isEnabled(SearchContext.builder().topK(3).build()));
+
+        SearchChannelResult result = channel.search(SearchContext.builder()
+                .originalQuestion("What is Retrieval-Augmented Generation?")
+                .topK(3)
+                .build());
+
+        assertFalse(result.getChunks().isEmpty(), "真实 API 应返回至少一条结果");
+        assertTrue(result.getChunks().get(0).getText().contains("来源: "), "Chunk 文本应包含来源链接");
+        System.out.println("[LIVE] You.com 返回 " + result.getChunks().size() + " 个 Chunk, 耗时 "
+                + result.getLatencyMs() + "ms");
+        System.out.println("[LIVE] 首条 Chunk:\n" + result.getChunks().get(0).getText());
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannelTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/channel/YouComWebSearchChannelTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieve.channel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
+import com.sun.net.httpserver.HttpServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * You.com 联网检索通道单元测试（离线，使用 JDK 内置 HttpServer 作为 stub，不依赖真实 Key）
+ */
+@DisplayName("You.com 联网检索通道")
+class YouComWebSearchChannelTest {
+
+    private static final String SAMPLE_BODY = """
+            {
+              "results": {
+                "web": [
+                  {
+                    "url": "https://example.com/a",
+                    "title": "网页结果A",
+                    "description": "描述A",
+                    "snippets": ["片段A1", "片段A2"]
+                  },
+                  {
+                    "url": "https://example.com/b",
+                    "title": "网页结果B",
+                    "description": "描述B"
+                  }
+                ],
+                "news": [
+                  {
+                    "url": "https://example.com/news",
+                    "title": "新闻结果",
+                    "description": "新闻描述"
+                  }
+                ]
+              },
+              "metadata": {"query": "test"}
+            }
+            """;
+
+    private HttpServer server;
+    private String stubUrl;
+
+    /**
+     * stub 收到的最近一次请求信息
+     */
+    private final AtomicReference<String> lastPath = new AtomicReference<>();
+    private final AtomicReference<String> lastApiKey = new AtomicReference<>();
+    private final AtomicReference<Map<String, String>> lastQueryParams = new AtomicReference<>();
+
+    /**
+     * stub 的响应控制
+     */
+    private volatile int responseCode = 200;
+    private volatile String responseBody = SAMPLE_BODY;
+    private volatile long responseDelayMs = 0;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/search", exchange -> {
+            lastPath.set(exchange.getRequestURI().getPath());
+            lastApiKey.set(exchange.getRequestHeaders().getFirst("X-API-Key"));
+            lastQueryParams.set(parseQuery(exchange.getRequestURI().getRawQuery()));
+            if (responseDelayMs > 0) {
+                try {
+                    Thread.sleep(responseDelayMs);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(responseCode, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        stubUrl = "http://localhost:" + server.getAddress().getPort() + "/v1/search";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    @DisplayName("请求构造：路径、X-API-Key 头、query 与 count 参数")
+    void requestConstruction() {
+        YouComWebSearchChannel channel = newChannel(defaultProperties("test-key"));
+
+        channel.search(context("什么是 RAG"));
+
+        assertEquals("/v1/search", lastPath.get());
+        assertEquals("test-key", lastApiKey.get());
+        assertEquals("什么是 RAG", lastQueryParams.get().get("query"));
+        assertEquals("5", lastQueryParams.get().get("count"));
+    }
+
+    @Test
+    @DisplayName("响应映射：web 与 news 均映射为 Chunk，id 取 url，text 含标题/描述/片段/来源")
+    void mapsWebAndNewsResults() {
+        YouComWebSearchChannel channel = newChannel(defaultProperties("test-key"));
+
+        SearchChannelResult result = channel.search(context("test"));
+
+        List<RetrievedChunk> chunks = result.getChunks();
+        assertEquals(3, chunks.size());
+        assertEquals(SearchChannelType.WEB_SEARCH, result.getChannelType());
+
+        RetrievedChunk first = chunks.get(0);
+        assertEquals("https://example.com/a", first.getId());
+        assertTrue(first.getText().contains("网页结果A"));
+        assertTrue(first.getText().contains("描述A"));
+        assertTrue(first.getText().contains("片段A1"));
+        assertTrue(first.getText().contains("来源: https://example.com/a"));
+
+        // news 也在列表内
+        assertEquals("https://example.com/news", chunks.get(2).getId());
+
+        // 分数非空且按名次递减（去重/RRF 处理器要求非 null 分数）
+        for (int i = 0; i < chunks.size(); i++) {
+            assertNotNull(chunks.get(i).getScore());
+            if (i > 0) {
+                assertTrue(chunks.get(i).getScore() < chunks.get(i - 1).getScore());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("响应映射：news 缺失、可选字段缺失均不报错")
+    void mapsWhenNewsAbsentAndOptionalFieldsMissing() {
+        responseBody = """
+                {"results": {"web": [{"url": "https://example.com/only-url"}, {"title": "只有标题"}]}}
+                """;
+        YouComWebSearchChannel channel = newChannel(defaultProperties("test-key"));
+
+        List<RetrievedChunk> chunks = channel.search(context("test")).getChunks();
+
+        assertEquals(2, chunks.size());
+        assertEquals("https://example.com/only-url", chunks.get(0).getId());
+        assertNull(chunks.get(1).getId());
+        assertTrue(chunks.get(1).getText().contains("只有标题"));
+    }
+
+    @Test
+    @DisplayName("count 参数：非法值回退默认 5，超过上限截断为 20")
+    void countDefaultAndCap() {
+        SearchChannelProperties properties = defaultProperties("test-key");
+        properties.getChannels().getWebSearch().setCount(50);
+        newChannel(properties).search(context("test"));
+        assertEquals("20", lastQueryParams.get().get("count"));
+
+        properties.getChannels().getWebSearch().setCount(0);
+        newChannel(properties).search(context("test"));
+        assertEquals("5", lastQueryParams.get().get("count"));
+    }
+
+    @Test
+    @DisplayName("启用判定：开关与 Key 缺一不可，配置 Key 为空时回退环境变量")
+    void isEnabledRequiresSwitchAndKey() {
+        // 开关开 + 配置 Key -> 启用
+        assertTrue(newChannel(defaultProperties("test-key")).isEnabled(context("q")));
+
+        // 开关关 + 有 Key -> 不启用
+        SearchChannelProperties disabled = defaultProperties("test-key");
+        disabled.getChannels().getWebSearch().setEnabled(false);
+        assertFalse(newChannel(disabled).isEnabled(context("q")));
+
+        // 开关开 + 无配置 Key + 无环境变量 -> 不启用
+        SearchChannelProperties noKey = defaultProperties("");
+        assertFalse(newChannelWithEnv(noKey, null).isEnabled(context("q")));
+
+        // 开关开 + 无配置 Key + 有环境变量 -> 启用（YDC_API_KEY 回退）
+        assertTrue(newChannelWithEnv(noKey, "env-key").isEnabled(context("q")));
+    }
+
+    @Test
+    @DisplayName("错误降级：401/429/500 返回空结果且不抛异常")
+    void httpErrorsDegradeToEmpty() {
+        for (int code : new int[]{401, 429, 500}) {
+            responseCode = code;
+            SearchChannelResult result = newChannel(defaultProperties("test-key")).search(context("test"));
+            assertTrue(result.getChunks().isEmpty(), "HTTP " + code + " 应降级为空结果");
+        }
+    }
+
+    @Test
+    @DisplayName("错误降级：响应非 JSON 返回空结果且不抛异常")
+    void malformedJsonDegradesToEmpty() {
+        responseBody = "not-a-json{{{";
+        SearchChannelResult result = newChannel(defaultProperties("test-key")).search(context("test"));
+        assertTrue(result.getChunks().isEmpty());
+    }
+
+    @Test
+    @DisplayName("错误降级：请求超时返回空结果且不抛异常")
+    void timeoutDegradesToEmpty() {
+        responseDelayMs = 3000;
+        SearchChannelProperties properties = defaultProperties("test-key");
+        properties.getChannels().getWebSearch().setTimeoutSeconds(1);
+
+        SearchChannelResult result = newChannel(properties).search(context("test"));
+
+        assertTrue(result.getChunks().isEmpty());
+    }
+
+    @Test
+    @DisplayName("问题为空时跳过请求，返回空结果")
+    void blankQuerySkips() {
+        SearchChannelResult result = newChannel(defaultProperties("test-key")).search(context(" "));
+        assertTrue(result.getChunks().isEmpty());
+        assertNull(lastPath.get(), "空问题不应发起请求");
+    }
+
+    @Test
+    @DisplayName("通道元信息：类型 WEB_SEARCH，优先级在本地通道之后")
+    void channelWiring() {
+        YouComWebSearchChannel channel = newChannel(defaultProperties("test-key"));
+        assertEquals(SearchChannelType.WEB_SEARCH, channel.getType());
+        assertEquals("YouComWebSearch", channel.getName());
+        assertTrue(channel.getPriority() > 10, "联网检索优先级应排在向量全局(10)之后");
+    }
+
+    // ============== helpers ==============
+
+    private SearchChannelProperties defaultProperties(String apiKey) {
+        SearchChannelProperties properties = new SearchChannelProperties();
+        SearchChannelProperties.WebSearch webSearch = properties.getChannels().getWebSearch();
+        webSearch.setEnabled(true);
+        webSearch.setApiKey(apiKey);
+        webSearch.setApiUrl(stubUrl);
+        webSearch.setTimeoutSeconds(5);
+        return properties;
+    }
+
+    private YouComWebSearchChannel newChannel(SearchChannelProperties properties) {
+        return newChannelWithEnv(properties, null);
+    }
+
+    /**
+     * 构造通道并固定环境变量读取结果，屏蔽真实运行环境，保证测试确定性
+     */
+    private YouComWebSearchChannel newChannelWithEnv(SearchChannelProperties properties, String envValue) {
+        return new YouComWebSearchChannel(new OkHttpClient(), new ObjectMapper(), properties) {
+            @Override
+            protected String readEnv(String name) {
+                return envValue;
+            }
+        };
+    }
+
+    private SearchContext context(String question) {
+        return SearchContext.builder()
+                .originalQuestion(question)
+                .topK(10)
+                .build();
+    }
+
+    private static Map<String, String> parseQuery(String rawQuery) {
+        Map<String, String> params = new HashMap<>();
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return params;
+        }
+        for (String pair : rawQuery.split("&")) {
+            int idx = pair.indexOf('=');
+            if (idx > 0) {
+                params.put(URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                        URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
+            }
+        }
+        return params;
+    }
+}

--- a/mcp-server/src/main/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutor.java
+++ b/mcp-server/src/main/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutor.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.mcp.executor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import io.modelcontextprotocol.spec.McpSchema.JsonSchema;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * You.com 联网搜索 MCP 工具
+ * <p>
+ * 基于 You.com Search API（GET https://ydc-index.io/v1/search，X-API-Key 鉴权），
+ * 返回带来源链接和摘录片段的网页与新闻结果；API Key 从环境变量 YDC_API_KEY 读取
+ * <p>
+ * 说明：mcp-server 模块保持自包含（不依赖 bootstrap / framework，见各模块 pom），
+ * 因此此处内置精简的 You.com HTTP 调用逻辑，与 bootstrap 检索通道中的实现属有意重复
+ */
+@Slf4j
+@Component
+public class YouComSearchMcpExecutor {
+
+    private static final String TOOL_ID = "youcom_search";
+
+    /**
+     * API Key 环境变量名（团队约定，勿改）
+     */
+    private static final String ENV_API_KEY = "YDC_API_KEY";
+
+    private static final int DEFAULT_COUNT = 5;
+
+    private static final int MAX_COUNT = 20;
+
+    private static final List<String> FRESHNESS_VALUES = List.of("day", "week", "month", "year");
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * You.com Search API 地址（可测试性：单元测试可指向本地 stub 服务）
+     */
+    String apiUrl = "https://ydc-index.io/v1/search";
+
+    @Bean
+    public McpServerFeatures.SyncToolSpecification youComSearchToolSpecification() {
+        return new McpServerFeatures.SyncToolSpecification(buildTool(),
+                (exchange, request) -> handleCall(request));
+    }
+
+    private Tool buildTool() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+
+        properties.put("query", Map.of(
+                "type", "string",
+                "description", "检索关键词或问题"
+        ));
+
+        properties.put("count", Map.of(
+                "type", "integer",
+                "description", "返回结果数量，默认 5，最大 20",
+                "default", 5
+        ));
+
+        properties.put("freshness", Map.of(
+                "type", "string",
+                "description", "结果时效过滤：day(一天内)、week(一周内)、month(一月内)、year(一年内)，不传则不限",
+                "enum", FRESHNESS_VALUES
+        ));
+
+        JsonSchema inputSchema = new JsonSchema(
+                "object", properties, List.of("query"), null, null, null);
+
+        return Tool.builder()
+                .name(TOOL_ID)
+                .description("基于 You.com Search API 的联网搜索，返回带来源链接和摘录片段的网页与新闻结果。需要配置 YDC_API_KEY 环境变量")
+                .inputSchema(inputSchema)
+                .build();
+    }
+
+    CallToolResult handleCall(CallToolRequest request) {
+        long startMs = System.currentTimeMillis();
+        try {
+            Map<String, Object> args = request.arguments() != null ? request.arguments() : Map.of();
+            String query = stringArg(args, "query");
+            Integer count = intArg(args, "count");
+            String freshness = stringArg(args, "freshness");
+
+            if (query == null || query.isBlank()) {
+                return errorResult("请提供检索关键词 query");
+            }
+            if (count == null || count <= 0) count = DEFAULT_COUNT;
+            if (count > MAX_COUNT) count = MAX_COUNT;
+            if (freshness != null && !freshness.isBlank() && !FRESHNESS_VALUES.contains(freshness)) {
+                return errorResult("freshness 参数不合法，可选值：" + String.join("、", FRESHNESS_VALUES));
+            }
+
+            String apiKey = readEnv(ENV_API_KEY);
+            if (apiKey == null || apiKey.isBlank()) {
+                return errorResult("You.com 联网搜索未配置：请先设置环境变量 YDC_API_KEY"
+                        + "（可在 https://you.com/platform/api-keys 获取），配置后重启 MCP Server 即可使用");
+            }
+
+            String result = doSearch(query, count, freshness, apiKey);
+
+            log.info("MCP 工具调用完成, toolId={}, query={}, count={}, elapsed={}ms",
+                    TOOL_ID, query, count, System.currentTimeMillis() - startMs);
+            return successResult(result);
+        } catch (Exception e) {
+            log.error("MCP 工具调用失败, toolId={}, elapsed={}ms",
+                    TOOL_ID, System.currentTimeMillis() - startMs, e);
+            return errorResult("搜索失败: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 调用 You.com Search API 并格式化结果文本
+     */
+    private String doSearch(String query, int count, String freshness, String apiKey) throws Exception {
+        StringBuilder url = new StringBuilder(apiUrl)
+                .append("?query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8))
+                .append("&count=").append(count);
+        if (freshness != null && !freshness.isBlank()) {
+            url.append("&freshness=").append(freshness);
+        }
+
+        HttpRequest httpRequest = HttpRequest.newBuilder(URI.create(url.toString()))
+                .timeout(Duration.ofSeconds(10))
+                .header("X-API-Key", apiKey)
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            // 不回显响应体，避免泄露账号信息；401 鉴权失败 / 429 限流 / 5xx 服务端异常
+            throw new IllegalStateException("You.com API 返回异常状态码: " + response.statusCode());
+        }
+
+        return formatResults(objectMapper.readTree(response.body()));
+    }
+
+    /**
+     * 把响应格式化为编号的 标题/链接/摘录 文本
+     * <p>
+     * 响应中 results.web 与 results.news 均可能缺失；
+     * 每条结果中除 url/title/description/snippets 之外的字段均视为可选，防御式读取
+     */
+    private String formatResults(JsonNode root) {
+        JsonNode results = root.path("results");
+        List<JsonNode> items = new ArrayList<>();
+        collectItems(items, results.path("web"));
+        collectItems(items, results.path("news"));
+
+        if (items.isEmpty()) {
+            return "未检索到相关结果，请尝试更换关键词。";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("检索完成，共 %d 条结果：\n\n", items.size()));
+        int index = 1;
+        for (JsonNode item : items) {
+            String title = item.path("title").asText("(无标题)");
+            String url = item.path("url").asText("");
+            String excerpt = resolveExcerpt(item);
+
+            sb.append(String.format("%d. %s\n", index++, title));
+            if (!url.isBlank()) {
+                sb.append("   链接: ").append(url).append('\n');
+            }
+            if (!excerpt.isBlank()) {
+                sb.append("   摘录: ").append(excerpt).append('\n');
+            }
+            sb.append('\n');
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * 摘录优先取 description，缺失时回退第一条 snippet
+     */
+    private String resolveExcerpt(JsonNode item) {
+        String description = item.path("description").asText("");
+        if (!description.isBlank()) {
+            return description;
+        }
+        JsonNode snippets = item.path("snippets");
+        if (snippets.isArray() && !snippets.isEmpty()) {
+            return snippets.get(0).asText("");
+        }
+        return "";
+    }
+
+    private void collectItems(List<JsonNode> items, JsonNode array) {
+        if (array != null && array.isArray()) {
+            array.forEach(items::add);
+        }
+    }
+
+    /**
+     * 读取环境变量（可测试性：单元测试可覆盖此方法屏蔽真实环境）
+     */
+    protected String readEnv(String name) {
+        return System.getenv(name);
+    }
+
+    private static String stringArg(Map<String, Object> args, String key) {
+        Object val = args.get(key);
+        return val != null ? val.toString() : null;
+    }
+
+    private static Integer intArg(Map<String, Object> args, String key) {
+        Object val = args.get(key);
+        if (val instanceof Number n) return n.intValue();
+        return null;
+    }
+
+    private static CallToolResult successResult(String text) {
+        return CallToolResult.builder()
+                .content(List.of(new TextContent(text)))
+                .isError(false)
+                .build();
+    }
+
+    private static CallToolResult errorResult(String message) {
+        return CallToolResult.builder()
+                .content(List.of(new TextContent(message)))
+                .isError(true)
+                .build();
+    }
+}

--- a/mcp-server/src/test/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutorLiveTest.java
+++ b/mcp-server/src/test/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutorLiveTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.mcp.executor;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * youcom_search MCP 工具真实 API 集成测试
+ * <p>
+ * 仅当环境变量 YDC_API_KEY 存在时运行（1 次真实调用），日常构建自动跳过
+ */
+@DisplayName("youcom_search MCP 工具（真实 API）")
+@EnabledIfEnvironmentVariable(named = "YDC_API_KEY", matches = ".+")
+class YouComSearchMcpExecutorLiveTest {
+
+    @Test
+    @DisplayName("真实检索返回编号结果文本")
+    void liveSearchReturnsFormattedResults() {
+        YouComSearchMcpExecutor executor = new YouComSearchMcpExecutor();
+
+        CallToolResult result = executor.handleCall(new CallToolRequest("youcom_search",
+                Map.of("query", "Model Context Protocol", "count", 3)));
+
+        assertFalse(result.isError(), "真实调用不应返回错误");
+        String text = ((TextContent) result.content().get(0)).text();
+        assertTrue(text.contains("1. "), "结果应包含编号列表");
+        assertTrue(text.contains("链接: "), "结果应包含来源链接");
+        System.out.println("[LIVE] youcom_search 返回:\n" + text);
+    }
+}

--- a/mcp-server/src/test/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutorTest.java
+++ b/mcp-server/src/test/java/com/nageoffer/ai/ragent/mcp/executor/YouComSearchMcpExecutorTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.mcp.executor;
+
+import com.sun.net.httpserver.HttpServer;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * youcom_search MCP 工具单元测试（离线，使用 JDK 内置 HttpServer 作为 stub，不依赖真实 Key）
+ */
+@DisplayName("youcom_search MCP 工具")
+class YouComSearchMcpExecutorTest {
+
+    private static final String SAMPLE_BODY = """
+            {
+              "results": {
+                "web": [
+                  {
+                    "url": "https://example.com/a",
+                    "title": "网页结果A",
+                    "description": "描述A",
+                    "snippets": ["片段A1"]
+                  },
+                  {
+                    "url": "https://example.com/b",
+                    "title": "网页结果B",
+                    "snippets": ["片段B1"]
+                  }
+                ],
+                "news": [
+                  {"url": "https://example.com/news", "title": "新闻结果", "description": "新闻描述"}
+                ]
+              }
+            }
+            """;
+
+    private HttpServer server;
+    private String stubUrl;
+
+    private final AtomicReference<String> lastApiKey = new AtomicReference<>();
+    private final AtomicReference<Map<String, String>> lastQueryParams = new AtomicReference<>();
+
+    private volatile int responseCode = 200;
+    private volatile String responseBody = SAMPLE_BODY;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/search", exchange -> {
+            lastApiKey.set(exchange.getRequestHeaders().getFirst("X-API-Key"));
+            lastQueryParams.set(parseQuery(exchange.getRequestURI().getRawQuery()));
+            byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(responseCode, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        stubUrl = "http://localhost:" + server.getAddress().getPort() + "/v1/search";
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    @DisplayName("工具 Schema：名称、必填参数与可选参数定义正确")
+    void toolSchema() {
+        Tool tool = new YouComSearchMcpExecutor().youComSearchToolSpecification().tool();
+
+        assertEquals("youcom_search", tool.name());
+        assertTrue(tool.description().contains("You.com"));
+        assertTrue(tool.description().contains("YDC_API_KEY"));
+        assertEquals(java.util.List.of("query"), tool.inputSchema().required());
+        assertTrue(tool.inputSchema().properties().containsKey("query"));
+        assertTrue(tool.inputSchema().properties().containsKey("count"));
+        assertTrue(tool.inputSchema().properties().containsKey("freshness"));
+    }
+
+    @Test
+    @DisplayName("缺少 query 参数返回 errorResult")
+    void missingQueryReturnsError() {
+        CallToolResult result = executor("any-key").handleCall(request(Map.of()));
+
+        assertTrue(result.isError());
+        assertTrue(text(result).contains("query"));
+    }
+
+    @Test
+    @DisplayName("缺少 YDC_API_KEY 返回带配置指引的 errorResult")
+    void missingKeyReturnsFriendlyError() {
+        CallToolResult result = executor(null).handleCall(request(Map.of("query", "test")));
+
+        assertTrue(result.isError());
+        assertTrue(text(result).contains("YDC_API_KEY"));
+        assertTrue(text(result).contains("you.com/platform/api-keys"));
+    }
+
+    @Test
+    @DisplayName("freshness 参数不合法返回 errorResult")
+    void invalidFreshnessReturnsError() {
+        CallToolResult result = executor("k").handleCall(
+                request(Map.of("query", "test", "freshness", "hour")));
+
+        assertTrue(result.isError());
+        assertTrue(text(result).contains("freshness"));
+    }
+
+    @Test
+    @DisplayName("成功检索：请求携带 X-API-Key，结果格式化为编号的标题/链接/摘录")
+    void successMapping() {
+        CallToolResult result = executor("test-key").handleCall(
+                request(Map.of("query", "什么是 RAG", "count", 3, "freshness", "week")));
+
+        assertFalse(result.isError());
+        assertEquals("test-key", lastApiKey.get());
+        assertEquals("什么是 RAG", lastQueryParams.get().get("query"));
+        assertEquals("3", lastQueryParams.get().get("count"));
+        assertEquals("week", lastQueryParams.get().get("freshness"));
+
+        String text = text(result);
+        assertTrue(text.contains("共 3 条结果"));
+        assertTrue(text.contains("1. 网页结果A"));
+        assertTrue(text.contains("链接: https://example.com/a"));
+        assertTrue(text.contains("摘录: 描述A"));
+        // description 缺失时回退第一条 snippet
+        assertTrue(text.contains("摘录: 片段B1"));
+        // news 结果也在列表内
+        assertTrue(text.contains("3. 新闻结果"));
+    }
+
+    @Test
+    @DisplayName("count 参数：超过上限截断为 20，非法值回退默认 5")
+    void countDefaultAndCap() {
+        executor("k").handleCall(request(Map.of("query", "t", "count", 50)));
+        assertEquals("20", lastQueryParams.get().get("count"));
+
+        executor("k").handleCall(request(Map.of("query", "t", "count", -1)));
+        assertEquals("5", lastQueryParams.get().get("count"));
+    }
+
+    @Test
+    @DisplayName("API 返回非 200 时返回 errorResult 且不抛异常")
+    void httpErrorReturnsErrorResult() {
+        responseCode = 500;
+        CallToolResult result = executor("k").handleCall(request(Map.of("query", "t")));
+
+        assertTrue(result.isError());
+        assertTrue(text(result).contains("500"));
+    }
+
+    @Test
+    @DisplayName("空结果集返回友好提示文本")
+    void emptyResults() {
+        responseBody = "{\"results\": {}}";
+        CallToolResult result = executor("k").handleCall(request(Map.of("query", "t")));
+
+        assertFalse(result.isError());
+        assertTrue(text(result).contains("未检索到相关结果"));
+    }
+
+    // ============== helpers ==============
+
+    /**
+     * 构造 executor：指向本地 stub，并固定环境变量读取结果，屏蔽真实运行环境
+     */
+    private YouComSearchMcpExecutor executor(String envKey) {
+        YouComSearchMcpExecutor executor = new YouComSearchMcpExecutor() {
+            @Override
+            protected String readEnv(String name) {
+                return envKey;
+            }
+        };
+        executor.apiUrl = stubUrl;
+        return executor;
+    }
+
+    private CallToolRequest request(Map<String, Object> args) {
+        return new CallToolRequest("youcom_search", args);
+    }
+
+    private static String text(CallToolResult result) {
+        return ((TextContent) result.content().get(0)).text();
+    }
+
+    private static Map<String, String> parseQuery(String rawQuery) {
+        Map<String, String> params = new HashMap<>();
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return params;
+        }
+        for (String pair : rawQuery.split("&")) {
+            int idx = pair.indexOf('=');
+            if (idx > 0) {
+                params.put(URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                        URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
+            }
+        }
+        return params;
+    }
+}


### PR DESCRIPTION
关联 Issue: https://github.com/nageoffer/ragent/issues/48

## 动机

ragent 的多路召回目前均面向本地知识库（向量全局 / 意图定向 / 关键词），缺少联网召回通道；MCP Server 侧也暂无联网搜索工具。本 PR 一次交付两部分：**You.com 联网检索通道** 与 **youcom_search MCP 工具**。纯增量改动，默认关闭，不影响任何现有链路。

## 变更内容

### 一、联网检索通道（bootstrap）

- `SearchChannelType` 新增 `WEB_SEARCH`
- 新增 `YouComWebSearchChannel`，完全按照现有 `SearchChannel` SPI 与 `KeywordSearchChannel` 的模式实现：
  - 启用条件缺一不可：`rag.search.channels.web-search.enabled=true` 且可解析到 API Key（配置 `api-key` 优先，为空回退环境变量 `YDC_API_KEY`）
  - 优先级 20，排在所有本地通道之后；由 `MultiChannelRetrievalEngine` 自动并行调度
  - 复用注入的 `syncHttpClient`（OkHttp），按通道配置收紧超时
  - 任何失败（网络异常 / 非 2xx / 解析失败 / 超时）仅记录 warn 并返回空结果，绝不影响本地召回
  - 初始分数采用通道内名次递减的中性分数 `1/(rank+1)`：多通道时 RRF 融合按名次覆盖分数，去重处理器需要非空分数做比较，开启 Rerank 时最终由精排重新打分（代码内有中文注释说明）
  - `RetrievedChunk` 无 metadata 字段，来源信息（【标题】/ 描述 / 摘录 / 来源 url）合入 text，id 取 url
- `SearchChannelProperties` 新增 `webSearch` 配置块；`application.yaml` 补充示例（默认 `enabled: false`）

### 二、MCP 工具（mcp-server）

- 新增 `YouComSearchMcpExecutor`，完全参照 `WeatherMcpExecutor` 的实现模式（SyncToolSpecification Bean、中文描述、success/error 封装、耗时日志）
- 工具 `youcom_search`：参数 query（必填）/ count（默认 5，上限 20）/ freshness；Key 取环境变量 `YDC_API_KEY`，未配置时返回友好中文提示
- mcp-server 模块不依赖 bootstrap，客户端使用 JDK HttpClient 自包含实现（代码内有注释说明）
- API Key 不出现在任何日志与错误信息中

## 测试

- 新增 18 个离线单元测试（JDK 内置 HttpServer 模拟，未引入任何新依赖）：请求构造、结果映射（web+news / news 缺失 / 可选字段缺失）、count 默认与上限、未配置 Key 时通道不启用、401/429/500/超时/异常 JSON 全部降级为空结果、工具 schema 与参数校验等 —— 全部通过
- 2 个环境变量门控在线测试（未设置 `YDC_API_KEY` 自动跳过），已实测通过
- **mcp-server 实际启动验证**（该模块无基础设施依赖）：streamable HTTP（`:9099/mcp`）走完整协议 initialize → tools/list（可见 youcom_search 完整 schema）→ tools/call 真实调用返回 3 条带来源结果；未配置 Key 的实例返回友好中文提示
- 全量 `mvnw test` 与 main 分支基线对比：差异仅为新增的 18 个通过测试与 2 个门控跳过，既有测试状态完全一致，零回归

## 备注

- 与本 PR 无关的既有现象：根 pom 的 surefire 配置引用了 `@{argLine}`，但项目中无插件（如 jacoco）定义该属性，导致 `mvnw test` 在 fork JVM 时直接崩溃。本地通过 settings.xml profile 绕过后完成了全量对比，仓库内未做任何改动 —— 如需要可另提一个小 PR 修复
- 测试方式：

```bash
./mvnw -pl bootstrap -am test -Dtest='YouCom*' -Dsurefire.failIfNoSpecifiedTests=false
./mvnw -pl mcp-server test -Dtest='YouCom*'
# 在线测试（可选，各 1 次真实调用）
export YDC_API_KEY=<你的 Key>   # 获取: https://you.com/platform/api-keys
```

---

**English summary**: Adds two things in one PR: (1) a You.com-backed WEB_SEARCH retrieval channel implementing the existing SearchChannel SPI (disabled by default, config + YDC_API_KEY env fallback, exception-isolated so web failures never affect local retrieval, RRF/rerank-aware neutral scoring), and (2) a youcom_search tool in the mcp-server module mirroring the existing executor pattern (self-contained JDK HttpClient, friendly Chinese guidance when unconfigured). 18 offline unit tests with zero new dependencies, 2 env-gated live tests, and a real standalone boot of the MCP server driving the full streamable-HTTP protocol with a live call. Also flags (without touching) a pre-existing surefire @{argLine} issue that breaks `mvnw test` on clean main.
