### PR TITLE
fix(build): 定义 argLine 默认属性，修复干净环境 mvnw test 直接崩溃

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
     </description>
 
     <properties>
+        <!-- surefire 配置中的 @{argLine} 需要该属性存在（通常由 jacoco 定义）；
+             未接入 jacoco 时给出空默认值，避免 fork 出的测试 JVM 收到字面量 @{argLine} 直接崩溃 -->
+        <argLine></argLine>
         <java.version>17</java.version>
         <spring-boot.version>3.5.7</spring-boot.version>
         <milvus-sdk.version>2.6.6</milvus-sdk.version>


### PR DESCRIPTION
## 问题

根 pom 的 surefire 配置引用了 `@{argLine}`（用于兼容 jacoco 等按需注入 JVM 参数的插件），但项目中没有任何插件定义 `argLine` 属性。surefire 因此把字面量 `@{argLine}` 直接传给 fork 出的测试 JVM，导致在干净环境执行 `./mvnw test` 时测试 JVM 立即崩溃，任何测试都无法运行：

```
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```

## 修复

properties 中定义空的 `argLine` 默认属性（附中文注释说明原因）。这是该问题的标准修法：

- 现在 `./mvnw test` 在干净 checkout 上可以正常运行
- 将来接入 jacoco 时其定义会正常覆盖该属性，`@{argLine}` 的延迟绑定语义完全保留
- 改动仅 pom 一处，无任何业务代码变更

## 验证

修复后 `./mvnw -pl bootstrap -am test -Dtest='ScheduleRefreshProcessorTest'`：`Tests run: 5, Failures: 0, Errors: 0`（修复前同命令直接 VM 崩溃）。

顺带说明：这个问题是我在做 #48（You.com 集成，PR #49）跑全量测试基线时发现的，与该 PR 相互独立，故单独提交。
