### PR TITLE
fix(rag): 修复检索去重与块合并的四个缺陷（哈希碰撞丢块 / NPE / 超限 / embeddingText 丢失）

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/core/chunk/blockaware/ChunkPacker.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/core/chunk/blockaware/ChunkPacker.java
@@ -84,7 +84,8 @@ public class ChunkPacker {
             // 再加会超预算: 先冲刷, 用尾部完整块作为重叠起点(留出容纳当前块的余量, 保证不超 maxChars)
             if (!buffer.isEmpty() && bufferLen + sepLen + addLen > maxChars) {
                 flush(buffer, result);
-                buffer = overlapTail(buffer, Math.min(overlapChars, maxChars - addLen));
+                // 重叠预算需同时扣除当前块与其前面的分隔符长度，否则合并结果可能超出 maxChars
+                buffer = overlapTail(buffer, Math.min(overlapChars, maxChars - addLen - SEPARATOR.length()));
                 bufferLen = bufferedLength(buffer);
             }
             bufferLen += (buffer.isEmpty() ? 0 : SEPARATOR.length()) + addLen;
@@ -162,6 +163,9 @@ public class ChunkPacker {
      */
     private static VectorChunk merge(List<VectorChunk> buffer) {
         StringBuilder content = new StringBuilder();
+        StringBuilder embeddingText = new StringBuilder();
+        boolean hasExplicitEmbeddingText = false;
+        String sectionContext = null;
         Set<String> sourceBlockIds = new LinkedHashSet<>();
         List<AssetRef> assets = new ArrayList<>();
         String blockType = buffer.get(0).getBlockType();
@@ -171,6 +175,25 @@ public class ChunkPacker {
                 content.append(SEPARATOR);
             }
             content.append(c.getContent() == null ? "" : c.getContent());
+            // embeddingText 不能在合并时丢弃：图片块特意用「无 URL 噪声」的描述文本做向量化，
+            // 丢弃后 embedding 会退化为携带原始 URL 的 content。任一块显式提供 embeddingText
+            // 时，合并块按「显式值优先、否则回退 content」逐块拼接
+            String effectiveEmbedding = c.getEmbeddingText() != null && !c.getEmbeddingText().isBlank()
+                    ? c.getEmbeddingText()
+                    : c.getContent();
+            if (c.getEmbeddingText() != null && !c.getEmbeddingText().isBlank()) {
+                hasExplicitEmbeddingText = true;
+            }
+            if (effectiveEmbedding != null && !effectiveEmbedding.isBlank()) {
+                if (!embeddingText.isEmpty()) {
+                    embeddingText.append(SEPARATOR);
+                }
+                embeddingText.append(effectiveEmbedding);
+            }
+            // sectionContext 取首个非空值（合并块与 outlinePath 一样归属共同上级章节）
+            if (sectionContext == null && c.getSectionContext() != null && !c.getSectionContext().isBlank()) {
+                sectionContext = c.getSectionContext();
+            }
             if (c.getSourceBlockIds() != null) {
                 sourceBlockIds.addAll(c.getSourceBlockIds());
             }
@@ -184,6 +207,8 @@ public class ChunkPacker {
         return VectorChunk.builder()
                 .chunkId(IdUtil.getSnowflakeNextIdStr())
                 .content(content.toString())
+                .embeddingText(hasExplicitEmbeddingText ? embeddingText.toString() : null)
+                .sectionContext(sectionContext)
                 .blockType(homogeneous ? blockType : "PARAGRAPH")
                 .outlinePath(commonPrefix(buffer))
                 .sourceBlockIds(new ArrayList<>(sourceBlockIds))

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/DeduplicationPostProcessor.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/DeduplicationPostProcessor.java
@@ -17,6 +17,7 @@
 
 package com.nageoffer.ai.ragent.rag.core.retrieve.postprocessor;
 
+import cn.hutool.crypto.digest.DigestUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchChannelResult;
 import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchChannelType;
@@ -75,9 +76,9 @@ public class DeduplicationPostProcessor implements SearchResultPostProcessor {
                             // 新 Chunk，直接添加
                             chunkMap.put(key, chunk);
                         } else {
-                            // 已存在，合并分数（取最高分）
+                            // 已存在，合并分数（取最高分；score 允许为 null，需空值安全比较）
                             RetrievedChunk existing = chunkMap.get(key);
-                            if (chunk.getScore() > existing.getScore()) {
+                            if (scoreOf(chunk) > scoreOf(existing)) {
                                 chunkMap.put(key, chunk);
                             }
                         }
@@ -91,10 +92,19 @@ public class DeduplicationPostProcessor implements SearchResultPostProcessor {
      * 生成 Chunk 唯一键
      */
     private String generateChunkKey(RetrievedChunk chunk) {
-        // 基于 id 或内容哈希生成唯一键
+        // 基于 id 或内容摘要生成唯一键
+        // 注意不能用 String.hashCode()：32 位哈希碰撞概率不可忽略（如 "Aa" 与 "BB"），
+        // 碰撞会把内容不同的 Chunk 误判为重复并静默丢弃，这里改用 SHA-256 内容摘要
         return chunk.getId() != null
                 ? chunk.getId()
-                : String.valueOf(chunk.getText().hashCode());
+                : DigestUtil.sha256Hex(chunk.getText() == null ? "" : chunk.getText());
+    }
+
+    /**
+     * 空值安全取分：score 为 null 时视为最低分，避免装箱 Float 拆箱 NPE
+     */
+    private static float scoreOf(RetrievedChunk chunk) {
+        return chunk.getScore() != null ? chunk.getScore() : Float.NEGATIVE_INFINITY;
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/FusionPostProcessor.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/FusionPostProcessor.java
@@ -17,6 +17,7 @@
 
 package com.nageoffer.ai.ragent.rag.core.retrieve.postprocessor;
 
+import cn.hutool.crypto.digest.DigestUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchChannelResult;
@@ -135,8 +136,10 @@ public class FusionPostProcessor implements SearchResultPostProcessor {
      * 生成 Chunk 融合键，与去重处理器保持一致（优先 id，缺失时退化为文本哈希）
      */
     private String chunkKey(RetrievedChunk chunk) {
+        // 与去重处理器一致改用 SHA-256：String.hashCode() 碰撞会让不同 Chunk 的
+        // RRF 分数被错误地累加到同一个键上
         return chunk.getId() != null
                 ? chunk.getId()
-                : String.valueOf(chunk.getText().hashCode());
+                : DigestUtil.sha256Hex(chunk.getText() == null ? "" : chunk.getText());
     }
 }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/core/chunk/blockaware/ChunkPackerTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/core/chunk/blockaware/ChunkPackerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.core.chunk.blockaware;
+
+import com.nageoffer.ai.ragent.core.chunk.VectorChunk;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 块级贪心打包回归测试
+ * <p>
+ * 覆盖两个历史缺陷：
+ * 1. 冲刷后重叠预算未扣除分隔符长度，合并块可超出 maxChars 上限
+ * 2. merge() 丢弃 embeddingText / sectionContext，图片块特意构造的
+ *    「无 URL 噪声」向量化文本在合并后退化为携带原始 URL 的 content
+ */
+class ChunkPackerTest {
+
+    private VectorChunk chunk(String content, String blockType, String embeddingText) {
+        return VectorChunk.builder()
+                .chunkId(content)
+                .content(content)
+                .blockType(blockType)
+                .embeddingText(embeddingText)
+                .build();
+    }
+
+    @Test
+    void packedChunkNeverExceedsMaxChars() {
+        List<VectorChunk> packed = new ChunkPacker().pack(List.of(
+                chunk("AAAAA", "PARAGRAPH", null),
+                chunk("BBBBB", "PARAGRAPH", null)
+        ), 10, 9);
+
+        for (VectorChunk c : packed) {
+            assertTrue(c.getContent().length() <= 10,
+                    "合并块长度 " + c.getContent().length() + " 超出 maxChars=10: [" + c.getContent() + "]");
+        }
+    }
+
+    @Test
+    void mergePreservesEmbeddingText() {
+        List<VectorChunk> packed = new ChunkPacker().pack(List.of(
+                chunk("![](http://img.example.com/a.png)", "IMAGE", "一张架构图：展示检索链路各组件关系"),
+                chunk("正文段落", "PARAGRAPH", null)
+        ), 200, 20);
+
+        boolean found = false;
+        for (VectorChunk c : packed) {
+            if (c.getEmbeddingText() != null && c.getEmbeddingText().contains("架构图")) {
+                found = true;
+                assertTrue(!c.getEmbeddingText().contains("http://img.example.com"),
+                        "embeddingText 不应退化为携带 URL 噪声的原文");
+            }
+        }
+        assertTrue(found, "合并后 embeddingText 不允许被丢弃");
+        assertNotNull(packed.get(0).getContent());
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/DeduplicationPostProcessorTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieve/postprocessor/DeduplicationPostProcessorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieve.postprocessor;
+
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchChannelResult;
+import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchChannelType;
+import com.nageoffer.ai.ragent.rag.core.retrieve.channel.SearchContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 去重处理器回归测试
+ * <p>
+ * 覆盖两个历史缺陷：
+ * 1. 无 id 的 Chunk 用 String.hashCode() 做去重键，哈希碰撞（如 "Aa" 与 "BB"）
+ *    会把内容不同的 Chunk 误判为重复并静默丢弃
+ * 2. score 为 null 时同键比较直接拆箱导致 NPE，去重处理器整体失效
+ */
+class DeduplicationPostProcessorTest {
+
+    private RetrievedChunk chunk(String id, String text, Float score) {
+        RetrievedChunk c = new RetrievedChunk();
+        c.setId(id);
+        c.setText(text);
+        c.setScore(score);
+        return c;
+    }
+
+    private List<SearchChannelResult> singleChannel(List<RetrievedChunk> chunks) {
+        return List.of(SearchChannelResult.builder()
+                .channelType(SearchChannelType.KEYWORD)
+                .channelName("Keyword")
+                .chunks(chunks)
+                .latencyMs(1)
+                .build());
+    }
+
+    @Test
+    void hashCollidingTextsAreNotDeduplicated() {
+        // "Aa" 与 "BB" 的 String.hashCode() 相同（均为 2112），但内容不同，不允许合并
+        assertEquals("Aa".hashCode(), "BB".hashCode(), "前置条件：两段文本哈希碰撞");
+        List<RetrievedChunk> chunks = new ArrayList<>();
+        chunks.add(chunk(null, "Aa", 0.9f));
+        chunks.add(chunk(null, "BB", 0.8f));
+
+        List<RetrievedChunk> out = new DeduplicationPostProcessor()
+                .process(chunks, singleChannel(chunks), SearchContext.builder().originalQuestion("q").topK(10).build());
+
+        assertEquals(2, out.size(), "哈希碰撞的不同内容 Chunk 不允许被去重合并");
+    }
+
+    @Test
+    void nullScoreDoesNotThrowOnTieBreak() {
+        List<RetrievedChunk> chunks = new ArrayList<>();
+        chunks.add(chunk("same-id", "文本A", null));
+        chunks.add(chunk("same-id", "文本B", 0.5f));
+
+        assertDoesNotThrow(() -> {
+            List<RetrievedChunk> out = new DeduplicationPostProcessor()
+                    .process(chunks, singleChannel(chunks), SearchContext.builder().originalQuestion("q").topK(10).build());
+            assertEquals(1, out.size(), "同 id 应去重为 1 条");
+            assertEquals(Float.valueOf(0.5f), out.get(0).getScore(), "应保留有分数的那条");
+        });
+    }
+}


### PR DESCRIPTION
在做 #48 / PR #49 的测试基线时深入审计了检索与分块相关代码，发现并修复了四个缺陷。每个缺陷都有对应的回归测试：**修复前全部失败，修复后全部通过**。

## 缺陷 1：去重键哈希碰撞导致不同内容被静默丢弃（wrong-result）

`DeduplicationPostProcessor#generateChunkKey` 对无 id 的 Chunk 用 `String.valueOf(text.hashCode())` 做去重键。`String.hashCode()` 是 32 位哈希，碰撞并不罕见（最小反例：`"Aa"` 与 `"BB"` 的 hashCode 均为 2112）。碰撞时内容不同的两个 Chunk 会被判定为重复，**其中一个被静默丢弃**。`FusionPostProcessor#chunkKey` 存在同样的键逻辑，碰撞会把不同 Chunk 的 RRF 分数错误地累加到同一个键上。

**修复**：两处兜底键统一改为 SHA-256 内容摘要。

## 缺陷 2：score 为 null 时去重处理器 NPE（crash）

`RetrievedChunk.score` 是可空的装箱 `Float`，但同键比较 `chunk.getScore() > existing.getScore()` 直接拆箱，score 为 null 即抛 NPE。引擎会兜住该异常并跳过整个去重处理器，导致重复内容流向下游。

**修复**：空值安全比较（null 视为最低分），与 `AbstractParallelRetriever.scoreOf` 的既有处理方式一致。

## 缺陷 3：块打包合并结果可超出 maxChars 上限（wrong-result）

`ChunkPacker` 冲刷后计算重叠预算 `Math.min(overlapChars, maxChars - addLen)` 未扣除 carry 与当前块之间的 `"\n\n"` 分隔符，合并块最长可达 `maxChars + 2`，违反类注释自身声明的「重叠计入 maxChars 预算, 保证块体量不超上限」。

**修复**：预算补扣 `SEPARATOR.length()`。

## 缺陷 4：merge() 丢弃 embeddingText 与 sectionContext（wrong-result）

图片块特意构造了去掉 URL 噪声的 `embeddingText` 用于向量化（ImageChunker 注释：「去掉 ![](url) 那行 URL 噪声」）。但 `ChunkPacker#merge` 的 builder 只复制 content/blockType/outlinePath/sourceBlockIds/assets，合并后 `embeddingText` 变为 null，向量化回退到携带原始 URL 的 content，图片检索质量退化；`sectionContext` 同样被丢弃。

**修复**：合并时按「显式 embeddingText 优先、否则回退 content」逐块拼接；`sectionContext` 取首个非空值（与 outlinePath 归属共同上级章节的语义一致）。

## 验证

```bash
./mvnw -pl bootstrap -am test -Dtest='DeduplicationPostProcessorTest,ChunkPackerTest' -Dsurefire.failIfNoSpecifiedTests=false
# 修复前: Tests run: 4, Failures: 4
# 修复后: Tests run: 4, Failures: 0
```

（注：在干净环境跑测试需要先合并 #50 的 argLine 修复，或本地定义空 argLine 属性。）

四处修复均为最小改动，不改变任何公开接口；与 #49、#50 相互独立。
