### PR TITLE
fix(ingestion): 修复 Pipeline 重复更新节点唯一键冲突

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionPipelineServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionPipelineServiceImpl.java
@@ -193,9 +193,7 @@ public class IngestionPipelineServiceImpl implements IngestionPipelineService {
         if (nodes == null) {
             return;
         }
-        LambdaQueryWrapper<IngestionPipelineNodeDO> qw = new LambdaQueryWrapper<IngestionPipelineNodeDO>()
-                .eq(IngestionPipelineNodeDO::getPipelineId, pipelineId);
-        nodeMapper.delete(qw);
+        nodeMapper.physicalDeleteByPipelineId(pipelineId);
         for (IngestionPipelineNodeRequest node : nodes) {
             if (node == null) {
                 continue;

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/dao/mapper/IngestionPipelineNodeMapperTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/dao/mapper/IngestionPipelineNodeMapperTest.java
@@ -17,13 +17,28 @@
 
 package com.nageoffer.ai.ragent.ingestion.dao.mapper;
 
-import com.baomidou.mybatisplus.core.mapper.BaseMapper;
-import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionPipelineNodeDO;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Param;
+import org.junit.jupiter.api.Test;
 
-public interface IngestionPipelineNodeMapper extends BaseMapper<IngestionPipelineNodeDO> {
+import java.lang.reflect.Method;
 
-    @Delete("DELETE FROM t_ingestion_pipeline_node WHERE pipeline_id = #{pipelineId}")
-    int physicalDeleteByPipelineId(@Param("pipelineId") String pipelineId);
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class IngestionPipelineNodeMapperTest {
+
+    @Test
+    void physicalDeleteByPipelineIdUsesHardDeleteSql() throws NoSuchMethodException {
+        Method method = IngestionPipelineNodeMapper.class.getMethod("physicalDeleteByPipelineId", String.class);
+
+        Delete delete = method.getAnnotation(Delete.class);
+        assertNotNull(delete);
+        assertEquals("DELETE FROM t_ingestion_pipeline_node WHERE pipeline_id = #{pipelineId}", delete.value()[0]);
+        assertEquals(int.class, method.getReturnType());
+
+        Param param = method.getParameters()[0].getAnnotation(Param.class);
+        assertNotNull(param);
+        assertEquals("pipelineId", param.value());
+    }
 }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionPipelineServiceImplTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionPipelineServiceImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.ingestion.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.audit.support.BizChangeLogContext;
+import com.nageoffer.ai.ragent.ingestion.controller.request.IngestionPipelineNodeRequest;
+import com.nageoffer.ai.ragent.ingestion.controller.request.IngestionPipelineUpdateRequest;
+import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionPipelineDO;
+import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionPipelineNodeDO;
+import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionPipelineMapper;
+import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionPipelineNodeMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IngestionPipelineServiceImplTest {
+
+    @Mock
+    private IngestionPipelineMapper pipelineMapper;
+
+    @Mock
+    private IngestionPipelineNodeMapper nodeMapper;
+
+    @Mock
+    private BizChangeLogContext bizChangeLogContext;
+
+    private IngestionPipelineServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IngestionPipelineServiceImpl(
+                pipelineMapper,
+                nodeMapper,
+                new ObjectMapper(),
+                bizChangeLogContext
+        );
+    }
+
+    @Test
+    void updatePhysicallyDeletesExistingNodesBeforeReinsertingThem() {
+        String pipelineId = "pipeline-1";
+        IngestionPipelineDO pipeline = IngestionPipelineDO.builder()
+                .id(pipelineId)
+                .name("default")
+                .build();
+        when(pipelineMapper.selectById(pipelineId)).thenReturn(pipeline);
+        when(nodeMapper.selectList(any())).thenReturn(List.of());
+
+        IngestionPipelineNodeRequest node = new IngestionPipelineNodeRequest();
+        node.setNodeId("fetcher-1");
+        node.setNodeType("fetcher");
+        IngestionPipelineUpdateRequest request = new IngestionPipelineUpdateRequest();
+        request.setNodes(List.of(node));
+
+        service.update(pipelineId, request);
+
+        InOrder order = inOrder(nodeMapper);
+        order.verify(nodeMapper).physicalDeleteByPipelineId(pipelineId);
+        order.verify(nodeMapper).insert(argThat((IngestionPipelineNodeDO inserted) ->
+                pipelineId.equals(inserted.getPipelineId())
+                        && "fetcher-1".equals(inserted.getNodeId())
+        ));
+    }
+}


### PR DESCRIPTION
## 问题

`t_ingestion_pipeline_node` 使用唯一约束 `(pipeline_id, node_id, deleted)`。
Pipeline 更新节点时，原实现通过 MyBatis-Plus `delete(...)` 清理旧节点；由于实体字段带有 `@TableLogic`，该调用实际执行的是 `deleted = 1`，并不会删除历史记录。

第一次更新后，数据库中会保留 `(pipeline_id, node_id, 1)`。第二次使用相同 `node_id` 更新时，再把当前记录从 `deleted = 0` 改为 `deleted = 1` 就会触发唯一键冲突。

## 根因

节点更新采用“整体替换”语义，但清理步骤使用了逻辑删除。逻辑删除历史与三列唯一约束无法支持相同节点的重复替换。

## 修复

- 在 `IngestionPipelineNodeMapper` 中增加按 `pipeline_id` 执行的参数化物理删除 SQL。
- `upsertNodes(...)` 在插入新节点前物理清空该 Pipeline 的全部节点记录。
- 保持现有事务边界；后续插入失败时，删除操作会一并回滚。

## 影响范围

- 仅改变 Pipeline 节点“整体替换”时的旧记录清理方式。
- 不修改数据库结构、Controller API 或节点配置格式。
- Pipeline 删除接口仍保留原有逻辑删除语义。

## 验证

新增两个回归测试：

1. 校验 Mapper 使用不带逻辑删除条件的物理 `DELETE` SQL。
2. 校验更新服务先物理删除旧节点，再插入新节点。

回归变异验证：将服务调用恢复为原逻辑 `nodeMapper.delete(qw)` 后，测试会失败并指出未调用物理删除：

```text
Tests run: 2, Failures: 1, Errors: 0
Wanted but not invoked: nodeMapper.physicalDeleteByPipelineId("pipeline-1")
```

最终实现：

```bash
./mvnw -pl bootstrap -am test -Dtest='IngestionPipelineNodeMapperTest,IngestionPipelineServiceImplTest' -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 2, Failures: 0, Errors: 0

./mvnw spotless:check
# BUILD SUCCESS
```

Fixes #45
