### PR TITLE
fix(memory): 避免摘要窗口每轮滑动都调用 LLM

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/memory/JdbcConversationMemorySummaryService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/memory/JdbcConversationMemorySummaryService.java
@@ -124,13 +124,19 @@ public class JdbcConversationMemorySummaryService implements ConversationMemoryS
             if (latestUserTurns.isEmpty()) {
                 return;
             }
-            String cutoffId = resolveCutoffId(latestUserTurns);
-            if (StrUtil.isBlank(cutoffId)) {
+            String historyStartId = resolveHistoryStartId(latestUserTurns);
+            if (StrUtil.isBlank(historyStartId)) {
                 return;
             }
 
             String afterId = resolveSummaryStartId(conversationId, userId, latestSummary);
-            if (afterId != null && Long.parseLong(afterId) >= Long.parseLong(cutoffId)) {
+            if (afterId != null && Long.parseLong(afterId) >= Long.parseLong(historyStartId)) {
+                return;
+            }
+
+            // 摘要覆盖约一半原文窗口；只有这段重叠滑出窗口后才再次生成摘要
+            String summaryCutoffId = resolveSummaryCutoffId(latestUserTurns);
+            if (StrUtil.isBlank(summaryCutoffId)) {
                 return;
             }
 
@@ -138,7 +144,7 @@ public class JdbcConversationMemorySummaryService implements ConversationMemoryS
                     conversationId,
                     userId,
                     afterId,
-                    cutoffId
+                    summaryCutoffId
             );
             if (CollUtil.isEmpty(toSummarize)) {
                 return;
@@ -253,7 +259,7 @@ public class JdbcConversationMemorySummaryService implements ConversationMemoryS
         return conversationGroupService.findMaxMessageIdAtOrBefore(conversationId, userId, after);
     }
 
-    private String resolveCutoffId(List<ConversationMessageDO> latestUserTurns) {
+    private String resolveHistoryStartId(List<ConversationMessageDO> latestUserTurns) {
         if (CollUtil.isEmpty(latestUserTurns)) {
             return null;
         }
@@ -261,6 +267,15 @@ public class JdbcConversationMemorySummaryService implements ConversationMemoryS
         // 倒序列表的最后一个就是最早的
         ConversationMessageDO oldest = latestUserTurns.get(latestUserTurns.size() - 1);
         return oldest == null ? null : oldest.getId();
+    }
+
+    private String resolveSummaryCutoffId(List<ConversationMessageDO> latestUserTurns) {
+        if (CollUtil.isEmpty(latestUserTurns)) {
+            return null;
+        }
+
+        ConversationMessageDO overlapBoundary = latestUserTurns.get((latestUserTurns.size() - 1) / 2);
+        return overlapBoundary == null ? null : overlapBoundary.getId();
     }
 
     private String resolveLastMessageId(List<ConversationMessageDO> toSummarize) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/memory/JdbcConversationMemorySummaryServiceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/memory/JdbcConversationMemorySummaryServiceTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.memory;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatMessage;
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.rag.config.MemoryProperties;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import com.nageoffer.ai.ragent.rag.dao.entity.ConversationMessageDO;
+import com.nageoffer.ai.ragent.rag.dao.entity.ConversationSummaryDO;
+import com.nageoffer.ai.ragent.rag.service.ConversationGroupService;
+import com.nageoffer.ai.ragent.rag.service.ConversationMessageService;
+import com.nageoffer.ai.ragent.rag.service.bo.ConversationSummaryBO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JdbcConversationMemorySummaryServiceTest {
+
+    private static final String CONVERSATION_ID = "conversation-1";
+    private static final String USER_ID = "user-1";
+
+    @Mock
+    private ConversationGroupService conversationGroupService;
+
+    @Mock
+    private ConversationMessageService conversationMessageService;
+
+    @Mock
+    private LLMService llmService;
+
+    @Mock
+    private PromptTemplateLoader promptTemplateLoader;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock lock;
+
+    private JdbcConversationMemorySummaryService service;
+
+    @BeforeEach
+    void setUp() {
+        MemoryProperties memoryProperties = new MemoryProperties();
+        memoryProperties.setSummaryEnabled(true);
+        memoryProperties.setSummaryStartTurns(5);
+        memoryProperties.setHistoryKeepTurns(4);
+        memoryProperties.setSummaryMaxChars(200);
+
+        Executor directExecutor = Runnable::run;
+        service = new JdbcConversationMemorySummaryService(
+                conversationGroupService,
+                conversationMessageService,
+                memoryProperties,
+                llmService,
+                promptTemplateLoader,
+                redissonClient,
+                directExecutor
+        );
+
+        when(redissonClient.getLock(anyString())).thenReturn(lock);
+        when(lock.tryLock()).thenReturn(true);
+        when(lock.isHeldByCurrentThread()).thenReturn(true);
+    }
+
+    @Test
+    void firstSummaryOverlapsHalfOfTheHistoryWindow() {
+        stubSummaryGeneration();
+        when(conversationGroupService.countUserMessages(CONVERSATION_ID, USER_ID)).thenReturn(5L);
+        when(conversationGroupService.listLatestUserOnlyMessages(CONVERSATION_ID, USER_ID, 4))
+                .thenReturn(latestUserTurns());
+        when(conversationGroupService.listMessagesBetweenIds(CONVERSATION_ID, USER_ID, null, "40"))
+                .thenReturn(List.of(
+                        message("10", "user"),
+                        message("39", "assistant")
+                ));
+
+        service.compressIfNeeded(CONVERSATION_ID, USER_ID, ChatMessage.assistant("answer"));
+
+        verify(conversationGroupService)
+                .listMessagesBetweenIds(CONVERSATION_ID, USER_ID, null, "40");
+        ArgumentCaptor<ConversationSummaryBO> summaryCaptor = ArgumentCaptor.forClass(ConversationSummaryBO.class);
+        verify(conversationMessageService).addMessageSummary(summaryCaptor.capture());
+        assertEquals("39", summaryCaptor.getValue().getLastMessageId());
+    }
+
+    @Test
+    void doesNotRefreshWhileSummaryCoverageStillOverlapsTheHistoryWindow() {
+        when(conversationGroupService.countUserMessages(CONVERSATION_ID, USER_ID)).thenReturn(6L);
+        when(conversationGroupService.findLatestSummary(CONVERSATION_ID, USER_ID))
+                .thenReturn(ConversationSummaryDO.builder()
+                        .content("existing summary")
+                        .lastMessageId("35")
+                        .build());
+        when(conversationGroupService.listLatestUserOnlyMessages(CONVERSATION_ID, USER_ID, 4))
+                .thenReturn(latestUserTurns());
+
+        service.compressIfNeeded(CONVERSATION_ID, USER_ID, ChatMessage.assistant("answer"));
+
+        verifyNoInteractions(llmService, conversationMessageService);
+    }
+
+    @Test
+    void refreshesFromPreviousCoverageOnceItFallsBehindTheHistoryWindow() {
+        stubSummaryGeneration();
+        when(conversationGroupService.countUserMessages(CONVERSATION_ID, USER_ID)).thenReturn(8L);
+        when(conversationGroupService.findLatestSummary(CONVERSATION_ID, USER_ID))
+                .thenReturn(ConversationSummaryDO.builder()
+                        .content("existing summary")
+                        .lastMessageId("15")
+                        .build());
+        when(conversationGroupService.listLatestUserOnlyMessages(CONVERSATION_ID, USER_ID, 4))
+                .thenReturn(latestUserTurns());
+        when(conversationGroupService.listMessagesBetweenIds(CONVERSATION_ID, USER_ID, "15", "40"))
+                .thenReturn(List.of(
+                        message("16", "user"),
+                        message("39", "assistant")
+                ));
+
+        service.compressIfNeeded(CONVERSATION_ID, USER_ID, ChatMessage.assistant("answer"));
+
+        verify(conversationGroupService)
+                .listMessagesBetweenIds(CONVERSATION_ID, USER_ID, "15", "40");
+        ArgumentCaptor<ConversationSummaryBO> summaryCaptor = ArgumentCaptor.forClass(ConversationSummaryBO.class);
+        verify(conversationMessageService).addMessageSummary(summaryCaptor.capture());
+        assertEquals("39", summaryCaptor.getValue().getLastMessageId());
+    }
+
+    private void stubSummaryGeneration() {
+        when(promptTemplateLoader.render(anyString(), anyMap())).thenReturn("summary prompt");
+        when(llmService.chat(any(ChatRequest.class))).thenReturn("updated summary");
+    }
+
+    private List<ConversationMessageDO> latestUserTurns() {
+        return List.of(
+                message("50", "user"),
+                message("40", "user"),
+                message("30", "user"),
+                message("20", "user")
+        );
+    }
+
+    private ConversationMessageDO message(String id, String role) {
+        return ConversationMessageDO.builder()
+                .id(id)
+                .role(role)
+                .content(role + "-" + id)
+                .build();
+    }
+}


### PR DESCRIPTION
## 问题

会话达到摘要阈值后，原实现同时把原文窗口中最早的用户消息作为：

1. 已有摘要是否需要刷新的判断边界；
2. 本次生成摘要的截止边界。

原文窗口每新增一轮就会向右滑动一次，因此已有摘要的 `lastMessageId` 会立即落后于新的窗口起点，导致阈值后的每轮对话都调用一次 LLM 生成摘要。

## 根因

摘要覆盖范围与原文窗口之间没有缓冲重叠区。刷新判断和摘要截止位置共用同一个边界，使窗口的每次滑动都被视为摘要覆盖失效。

## 修复

- 使用原文窗口最早的用户消息 `historyStartId` 判断已有摘要覆盖是否已经滑出窗口。
- 将 `summaryCutoffId` 放在倒序原文窗口的中部，摘要覆盖约一半仍保留在原文窗口中的消息。
- 只有这段重叠全部滑出窗口后才刷新摘要，避免每轮调用 LLM。
- 保持摘要末尾与原文窗口起点连续，不产生历史记忆空洞。
- 不增加配置项，不修改公开 API。

## 行为变化与取舍

以当前 `history-keep-turns: 4` 为例，达到阈值后摘要刷新频率由每轮一次降为约每两轮一次。代价是摘要与原文保留一段有界重叠，这是为了换取连续上下文并降低调用频率。

## 验证

新增三个回归测试：

1. 首次摘要覆盖约一半原文窗口。
2. 摘要覆盖仍与原文窗口重叠时不调用 LLM。
3. 重叠滑出窗口后，从上次覆盖位置继续生成摘要。

回归变异验证：将摘要截止位置恢复为原窗口最早消息后，测试捕获到截止边界从期望的 `40` 退回 `20`：

```text
Tests run: 3, Failures: 2, Errors: 0
Wanted beforeId: 40
Actual beforeId: 20
```

最终实现：

```bash
./mvnw -pl bootstrap -am test -Dtest='JdbcConversationMemorySummaryServiceTest' -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 3, Failures: 0, Errors: 0

./mvnw spotless:check
# BUILD SUCCESS
```

Fixes #17
