### PR TITLE
fix(feedback): 修复取消点赞/点踩后反馈状态未持久化的问题

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/controller/MessageFeedbackController.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/controller/MessageFeedbackController.java
@@ -22,6 +22,7 @@ import com.nageoffer.ai.ragent.framework.convention.Result;
 import com.nageoffer.ai.ragent.framework.web.Results;
 import com.nageoffer.ai.ragent.rag.service.MessageFeedbackService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,6 +44,15 @@ public class MessageFeedbackController {
     public Result<Void> submitFeedback(@PathVariable String messageId,
                                        @RequestBody MessageFeedbackRequest request) {
         feedbackService.submitFeedbackAsync(messageId, request);
+        return Results.success();
+    }
+
+    /**
+     * 取消点赞/踩反馈（异步，通过 MQ 持久化）
+     */
+    @DeleteMapping("/conversations/messages/{messageId}/feedback")
+    public Result<Void> cancelFeedback(@PathVariable String messageId) {
+        feedbackService.cancelFeedbackAsync(messageId);
         return Results.success();
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dao/mapper/MessageFeedbackMapper.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dao/mapper/MessageFeedbackMapper.java
@@ -19,6 +19,42 @@ package com.nageoffer.ai.ragent.rag.dao.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.nageoffer.ai.ragent.rag.dao.entity.MessageFeedbackDO;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
 
 public interface MessageFeedbackMapper extends BaseMapper<MessageFeedbackDO> {
+
+    @Insert("""
+            INSERT INTO t_message_feedback
+                (id, message_id, conversation_id, user_id, vote, reason, comment, create_time, update_time, deleted)
+            VALUES
+                (#{feedback.id}, #{feedback.messageId}, #{feedback.conversationId}, #{feedback.userId},
+                 #{feedback.vote}, #{feedback.reason}, #{feedback.comment},
+                 #{feedback.createTime}, #{feedback.updateTime}, 0)
+            ON CONFLICT (message_id, user_id) DO UPDATE SET
+                conversation_id = EXCLUDED.conversation_id,
+                vote = EXCLUDED.vote,
+                reason = EXCLUDED.reason,
+                comment = EXCLUDED.comment,
+                update_time = EXCLUDED.update_time,
+                deleted = 0
+            WHERE t_message_feedback.update_time < EXCLUDED.update_time
+            """)
+    int upsertActiveFeedback(@Param("feedback") MessageFeedbackDO feedback);
+
+    /**
+     * 写入取消反馈；记录不存在时创建逻辑删除占位，保证重复取消幂等。
+     */
+    @Insert("""
+            INSERT INTO t_message_feedback
+                (id, message_id, conversation_id, user_id, vote, reason, comment, create_time, update_time, deleted)
+            VALUES
+                (#{feedback.id}, #{feedback.messageId}, #{feedback.conversationId}, #{feedback.userId},
+                 0, NULL, NULL, #{feedback.createTime}, #{feedback.updateTime}, 1)
+            ON CONFLICT (message_id, user_id) DO UPDATE SET
+                update_time = EXCLUDED.update_time,
+                deleted = 1
+            WHERE t_message_feedback.update_time < EXCLUDED.update_time
+            """)
+    int upsertCancelledFeedback(@Param("feedback") MessageFeedbackDO feedback);
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/mq/MessageFeedbackConsumer.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/mq/MessageFeedbackConsumer.java
@@ -44,8 +44,8 @@ public class MessageFeedbackConsumer implements RocketMQListener<MessageWrapper<
     public void onMessage(MessageWrapper<MessageFeedbackEvent> message) {
         MessageFeedbackEvent event = message.getBody();
 
-        log.info("[消费者] 开始处理点赞/点踩事件，messageId: {}, userId: {}, vote: {}, keys: {}",
-                event.getMessageId(), event.getUserId(), event.getVote(), message.getKeys());
+        log.info("[消费者] 开始处理反馈事件，messageId: {}, userId: {}, vote: {}, cancelled: {}, keys: {}",
+                event.getMessageId(), event.getUserId(), event.getVote(), event.isCancelled(), message.getKeys());
         feedbackService.submitFeedbackByEvent(event);
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/mq/event/MessageFeedbackEvent.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/mq/event/MessageFeedbackEvent.java
@@ -63,6 +63,11 @@ public class MessageFeedbackEvent implements Serializable {
     private String comment;
 
     /**
+     * 是否为取消反馈事件；旧消息缺少该字段时默认为 false
+     */
+    private boolean cancelled;
+
+    /**
      * 用户提交时间戳（毫秒），用于多节点消费时保证最终一致性
      */
     private long submitTime;

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/MessageFeedbackService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/MessageFeedbackService.java
@@ -42,6 +42,13 @@ public interface MessageFeedbackService {
     void submitFeedbackAsync(String messageId, MessageFeedbackRequest request);
 
     /**
+     * 取消会话消息反馈（异步，通过 MQ 持久化）
+     *
+     * @param messageId 消息ID
+     */
+    void cancelFeedbackAsync(String messageId);
+
+    /**
      * 通过 MQ 事件异步持久化反馈（由消费者调用）
      *
      * @param event 反馈事件

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/MessageFeedbackServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/MessageFeedbackServiceImpl.java
@@ -74,6 +74,21 @@ public class MessageFeedbackServiceImpl implements MessageFeedbackService {
     }
 
     @Override
+    public void cancelFeedbackAsync(String messageId) {
+        String userId = UserContext.getUserId();
+        Assert.notBlank(userId, () -> new ClientException("未获取到当前登录用户"));
+        Assert.notBlank(messageId, () -> new ClientException("消息ID不能为空"));
+
+        MessageFeedbackEvent event = MessageFeedbackEvent.builder()
+                .messageId(messageId)
+                .userId(userId)
+                .cancelled(true)
+                .submitTime(System.currentTimeMillis())
+                .build();
+        messageQueueProducer.send(feedbackTopic, userId + ":" + messageId, "取消消息反馈", event);
+    }
+
+    @Override
     public void submitFeedback(String messageId, MessageFeedbackRequest request) {
         String userId = UserContext.getUserId();
         Assert.notBlank(userId, () -> new ClientException("未获取到当前登录用户"));
@@ -141,7 +156,7 @@ public class MessageFeedbackServiceImpl implements MessageFeedbackService {
                     .reason(reason)
                     .comment(comment)
                     .build();
-            feedbackMapper.insert(feedback);
+            feedbackMapper.upsertActiveFeedback(feedback);
         } else {
             // 仅当本次提交时间晚于记录最后更新时间时才覆盖，避免多节点并行消费乱序
             feedbackMapper.update(
@@ -163,8 +178,18 @@ public class MessageFeedbackServiceImpl implements MessageFeedbackService {
         String userId = event.getUserId();
         Assert.notBlank(messageId, () -> new ClientException("消息ID不能为空"));
         Assert.notBlank(userId, () -> new ClientException("用户ID不能为空"));
-        Assert.notNull(event.getVote(), () -> new ClientException("反馈值不能为空"));
+        if (event.isCancelled()) {
+            ConversationMessageDO message = loadAssistantMessage(messageId, userId);
+            MessageFeedbackDO feedback = MessageFeedbackDO.builder()
+                    .messageId(messageId)
+                    .conversationId(message.getConversationId())
+                    .userId(userId)
+                    .build();
+            feedbackMapper.upsertCancelledFeedback(feedback);
+            return;
+        }
 
+        Assert.notNull(event.getVote(), () -> new ClientException("反馈值不能为空"));
         ConversationMessageDO message = loadAssistantMessage(messageId, userId);
         doUpsertFeedback(
                 messageId,

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -9,3 +9,7 @@ export async function submitFeedback(messageId: string, vote: number) {
     vote
   });
 }
+
+export async function cancelFeedback(messageId: string) {
+  return api.delete<void>(`/conversations/messages/${messageId}/feedback`);
+}

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -8,7 +8,7 @@ import {
   deleteSession as deleteSessionRequest,
   renameSession as renameSessionRequest
 } from "@/services/sessionService";
-import { stopTask, submitFeedback } from "@/services/chatService";
+import { stopTask, submitFeedback, cancelFeedback } from "@/services/chatService";
 import { buildQuery } from "@/utils/helpers";
 import { createStreamResponse } from "@/hooks/useStreamResponse";
 import { storage } from "@/utils/storage";
@@ -508,11 +508,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         message.id === messageId ? { ...message, feedback } : message
       )
     }));
-    if (vote === null) {
-      toast.success("取消成功");
-      return;
-    }
     try {
+      if (vote === null) {
+        await cancelFeedback(messageId);
+        toast.success("取消成功");
+        return;
+      }
       await submitFeedback(messageId, vote);
       toast.success(feedback === "like" ? "点赞成功" : "点踩成功");
     } catch (error) {
@@ -521,7 +522,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           message.id === messageId ? { ...message, feedback: prev } : message
         )
       }));
-      toast.error((error as Error).message || "反馈保存失败");
+      toast.error((error as Error).message || (vote === null ? "取消反馈失败" : "反馈保存失败"));
     }
   }
 }));


### PR DESCRIPTION
## 问题

用户点赞或点踩后，再次点击对应按钮取消反馈，前端会提示“取消成功”，但取消操作没有调用后端接口。

因此，数据库中的反馈记录仍然存在，刷新页面后点赞或点踩状态会重新出现。

## 根因

现有反馈链路只支持提交点赞和点踩。

取消反馈时，前端仅修改了本地消息状态，没有经过后端和 MQ 链路进行持久化，导致页面状态与数据库状态不一致。

## 修复

- 新增取消消息反馈接口。
- 前端取消反馈时调用后端接口，并在请求失败时恢复原状态。
- 取消反馈复用现有 RocketMQ 消息链路异步持久化。
- 扩展反馈事件以区分提交反馈和取消反馈。
- 使用 Upsert 处理反馈提交和取消，支持重复操作以及取消后重新反馈。

## 验证

- 点赞或点踩后刷新页面，反馈状态正常保留。
- 取消点赞或点踩后刷新页面，原反馈状态不再出现。
- 取消反馈后可以重新点赞或点踩。