### PR TITLE
优化 RAG 请求级 Query Embedding 批量计算与复用

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
@@ -62,9 +62,38 @@ public class MultiChannelRetrievalEngine {
      */
     @RagTraceNode(name = "multi-channel-retrieval", type = "RETRIEVE_CHANNEL")
     public List<RetrievedChunk> retrieveKnowledgeChannels(List<SubQuestionIntent> subIntents, RetrievalBudget budget) {
-        // 构建检索上下文
-        SearchContext context = buildSearchContext(subIntents, budget);
+        List<SearchContext> contexts = prepareKnowledgeChannels(subIntents, budget);
+        if (contexts.isEmpty()) {
+            return List.of();
+        }
+        return retrieveKnowledgeChannels(contexts.get(0));
+    }
 
+    /**
+     * 为同一请求中的全部子问题构建上下文，并让各检索通道集中完成批量准备。
+     */
+    public List<SearchContext> prepareKnowledgeChannels(List<SubQuestionIntent> subIntents, RetrievalBudget budget) {
+        if (CollUtil.isEmpty(subIntents)) {
+            return List.of();
+        }
+        List<SearchContext> contexts = subIntents.stream()
+                .map(subIntent -> buildSearchContext(List.of(subIntent), budget))
+                .toList();
+        for (SearchChannel channel : searchChannels) {
+            List<SearchContext> enabledContexts = contexts.stream()
+                    .filter(channel::isEnabled)
+                    .toList();
+            if (!enabledContexts.isEmpty()) {
+                channel.prepare(enabledContexts);
+            }
+        }
+        return contexts;
+    }
+
+    /**
+     * 使用已完成请求级准备的上下文执行知识检索。
+     */
+    public List<RetrievedChunk> retrieveKnowledgeChannels(SearchContext context) {
         // 【阶段1：多通道并行检索】
         List<SearchChannelResult> channelResults = executeSearchChannels(context);
         if (CollUtil.isEmpty(channelResults)) {

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
@@ -31,6 +31,7 @@ import com.nageoffer.ai.ragent.rag.core.mcp.McpToolExecutor;
 import com.nageoffer.ai.ragent.rag.core.mcp.McpToolRegistry;
 import com.nageoffer.ai.ragent.rag.core.prompt.ContextFormatter;
 import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchContext;
 import com.nageoffer.ai.ragent.rag.dto.KbResult;
 import com.nageoffer.ai.ragent.rag.dto.RetrievalContext;
 import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
@@ -49,6 +50,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.CONTEXT_FORMAT_PATH;
 import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.MULTI_CHANNEL_KEY;
@@ -90,11 +92,15 @@ public class RetrievalEngine {
                 searchProperties.getFusion().getRerankCandidateLimit(),
                 contextTopK
         );
-        List<CompletableFuture<SubQuestionContext>> tasks = subIntents.stream()
-                .map(si -> CompletableFuture.supplyAsync(
+        // 先构建全部子问题的检索任务并完成请求级批量准备，再并行执行各子问题。
+        // 这样查询向量可以按实际 Collection 对应的模型集中计算并在当前请求内复用。
+        List<SearchContext> searchContexts = multiChannelRetrievalEngine.prepareKnowledgeChannels(subIntents, budget);
+        List<CompletableFuture<SubQuestionContext>> tasks = IntStream.range(0, subIntents.size())
+                .mapToObj(index -> CompletableFuture.supplyAsync(
                         () -> {
+                            SubQuestionIntent si = subIntents.get(index);
                             try {
-                                return buildSubQuestionContext(si, budget);
+                                return buildSubQuestionContext(si, budget, searchContexts.get(index));
                             } catch (Exception e) {
                                 log.error("子问题上下文构建失败，降级为空上下文，question：{}", si.subQuestion(), e);
                                 return new SubQuestionContext(si.subQuestion(), "", "", Map.of());
@@ -150,11 +156,13 @@ public class RetrievalEngine {
                 .build();
     }
 
-    private SubQuestionContext buildSubQuestionContext(SubQuestionIntent intent, RetrievalBudget budget) {
+    private SubQuestionContext buildSubQuestionContext(SubQuestionIntent intent,
+                                                       RetrievalBudget budget,
+                                                       SearchContext searchContext) {
         List<NodeScore> kbIntents = NodeScoreFilters.kb(intent.nodeScores());
         List<NodeScore> mcpIntents = NodeScoreFilters.mcp(intent.nodeScores());
 
-        KbResult kbResult = retrieveAndRerank(intent, kbIntents, budget);
+        KbResult kbResult = retrieveAndRerank(intent, kbIntents, budget, searchContext);
 
         String mcpContext = CollUtil.isNotEmpty(mcpIntents)
                 ? executeMcpAndMerge(intent.subQuestion(), mcpIntents)
@@ -187,10 +195,12 @@ public class RetrievalEngine {
         return contextFormatter.formatMcpContext(toolResults, mcpIntents);
     }
 
-    private KbResult retrieveAndRerank(SubQuestionIntent intent, List<NodeScore> kbIntents, RetrievalBudget budget) {
+    private KbResult retrieveAndRerank(SubQuestionIntent intent,
+                                       List<NodeScore> kbIntents,
+                                       RetrievalBudget budget,
+                                       SearchContext searchContext) {
         // 使用多通道检索引擎（是否启用全局检索由置信度阈值决定）
-        List<SubQuestionIntent> subIntents = List.of(intent);
-        List<RetrievedChunk> chunks = multiChannelRetrievalEngine.retrieveKnowledgeChannels(subIntents, budget);
+        List<RetrievedChunk> chunks = multiChannelRetrievalEngine.retrieveKnowledgeChannels(searchContext);
 
         if (CollUtil.isEmpty(chunks)) {
             return KbResult.empty();

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/SearchChannel.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/SearchChannel.java
@@ -17,6 +17,8 @@
 
 package com.nageoffer.ai.ragent.rag.core.retrieval.channel;
 
+import java.util.List;
+
 /**
  * 检索通道接口
  * <p>
@@ -28,6 +30,16 @@ package com.nageoffer.ai.ragent.rag.core.retrieval.channel;
  * 多个通道可以并行执行，最后统一合并结果
  */
 public interface SearchChannel {
+
+    /**
+     * 在通道并行执行前准备请求级共享数据。
+     * <p>
+     * 默认无需准备；需要批量预处理的通道可覆盖此方法。
+     *
+     * @param contexts 同一请求内即将执行的检索上下文
+     */
+    default void prepare(List<SearchContext> contexts) {
+    }
 
     /**
      * 通道名称（用于日志和监控）

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannel.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannel.java
@@ -22,14 +22,21 @@ import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScoreFilters;
+import com.nageoffer.ai.ragent.rag.core.vector.QueryEmbeddingBatcher;
+import com.nageoffer.ai.ragent.rag.core.vector.QueryEmbeddingContext;
+import com.nageoffer.ai.ragent.rag.core.vector.SearchTask;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
 import com.nageoffer.ai.ragent.rag.core.vector.strategy.CollectionParallelRetriever;
 import com.nageoffer.ai.ragent.rag.core.vector.strategy.IntentParallelRetriever;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 /**
@@ -44,8 +51,11 @@ import java.util.concurrent.Executor;
 @Component
 public class VectorSearchChannel implements SearchChannel {
 
+    private static final String PLANNED_COLLECTIONS_KEY = VectorSearchChannel.class.getName() + ".collections";
+
     private final SearchChannelProperties properties;
     private final KbCollectionProvider kbCollectionProvider;
+    private final QueryEmbeddingBatcher queryEmbeddingBatcher;
     private final VectorRetrieverService retrieverService;
     private final IntentParallelRetriever intentRetriever;
     private final CollectionParallelRetriever globalRetriever;
@@ -53,9 +63,11 @@ public class VectorSearchChannel implements SearchChannel {
     public VectorSearchChannel(VectorRetrieverService retrieverService,
                                SearchChannelProperties properties,
                                KbCollectionProvider kbCollectionProvider,
+                               QueryEmbeddingBatcher queryEmbeddingBatcher,
                                Executor innerRetrievalExecutor) {
         this.properties = properties;
         this.kbCollectionProvider = kbCollectionProvider;
+        this.queryEmbeddingBatcher = queryEmbeddingBatcher;
         this.retrieverService = retrieverService;
         this.intentRetriever = new IntentParallelRetriever(retrieverService, innerRetrievalExecutor);
         this.globalRetriever = new CollectionParallelRetriever(retrieverService, innerRetrievalExecutor);
@@ -70,6 +82,41 @@ public class VectorSearchChannel implements SearchChannel {
     public boolean isEnabled(SearchContext context) {
         // 一条通道一个开关；启用后内部总有一条作用域可走（意图定向或全局兜底）
         return properties.getChannels().getVector().isEnabled();
+    }
+
+    @Override
+    public void prepare(List<SearchContext> contexts) {
+        List<SearchTask> scopedTasks = new ArrayList<>();
+        List<String> globalQuestions = new ArrayList<>();
+        Map<SearchContext, Boolean> globalScopes = new java.util.IdentityHashMap<>();
+
+        for (SearchContext context : contexts) {
+            List<NodeScore> kbIntents = extractKbIntents(context);
+            boolean global = !shouldNarrowToIntent(kbIntents);
+            globalScopes.put(context, global);
+            if (global) {
+                globalQuestions.add(context.getMainQuestion());
+                continue;
+            }
+            kbIntents.stream()
+                    .map(NodeScore::getNode)
+                    .filter(Objects::nonNull)
+                    .map(node -> node.getCollectionName())
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .forEach(collection -> scopedTasks.add(new SearchTask(context.getMainQuestion(), collection)));
+        }
+
+        QueryEmbeddingContext embeddingContext = queryEmbeddingBatcher.prepare(scopedTasks, globalQuestions);
+        for (SearchContext context : contexts) {
+            context.getMetadata().put(QueryEmbeddingContext.METADATA_KEY, embeddingContext);
+            if (Boolean.TRUE.equals(globalScopes.get(context)) && embeddingContext.isPrepared()) {
+                context.getMetadata().put(
+                        PLANNED_COLLECTIONS_KEY,
+                        embeddingContext.collectionsFor(context.getMainQuestion())
+                );
+            }
+        }
     }
 
     @Override
@@ -166,7 +213,11 @@ public class VectorSearchChannel implements SearchChannel {
     private List<RetrievedChunk> retrieveByIntent(SearchContext context, List<NodeScore> kbIntents) {
         log.info("执行向量检索（意图作用域），命中 {} 个 KB 意图，问题：{}", kbIntents.size(), context.getMainQuestion());
         return intentRetriever.retrieveByIntents(
-                context.getMainQuestion(), kbIntents, context.getBudget().recallBudget());
+                context.getMainQuestion(),
+                kbIntents,
+                context.getBudget().recallBudget(),
+                embeddingContext(context)
+        );
     }
 
     /**
@@ -175,7 +226,11 @@ public class VectorSearchChannel implements SearchChannel {
     private List<RetrievedChunk> retrieveGlobal(SearchContext context) {
         log.info("执行向量检索（全局作用域），问题：{}", context.getMainQuestion());
 
-        List<String> collections = kbCollectionProvider.listActiveCollections();
+        QueryEmbeddingContext embeddingContext = embeddingContext(context);
+        List<String> collections = plannedCollections(context);
+        if (collections.isEmpty() && !embeddingContext.isPrepared()) {
+            collections = kbCollectionProvider.listActiveCollections();
+        }
         if (collections.isEmpty()) {
             log.warn("未找到任何 KB collection，跳过全局检索");
             return List.of();
@@ -183,12 +238,67 @@ public class VectorSearchChannel implements SearchChannel {
 
         SearchChannelProperties.Global config = properties.getChannels().getVector().getGlobal();
         if (retrieverService.supportsGlobalRetrieval()) {
-            // 后端支持单次全局检索（如 PG）：一条带总预算的 SQL 跨库召回。candidate-budget 未配置时跟随 Rerank 候选池上限
             int budget = config.resolveCandidateBudget(context.getBudget().candidateLimit());
-            return retrieverService.retrieveGlobal(context.getMainQuestion(), collections, budget);
+            if (!embeddingContext.isPrepared()) {
+                return retrieverService.retrieveGlobal(context.getMainQuestion(), collections, budget);
+            }
+            return retrieveGlobalByModel(context.getMainQuestion(), collections, budget, embeddingContext);
         }
         // 后端不支持单次全局检索时：退化为逐库并行 fan-out 兜底，每库取候选预算，合并后交下游截断
         int perCollectionBudget = config.resolveCandidateBudget(context.getBudget().candidateLimit());
-        return globalRetriever.executeParallelRetrieval(context.getMainQuestion(), collections, perCollectionBudget);
+        return globalRetriever.retrieveByCollections(
+                context.getMainQuestion(),
+                collections,
+                perCollectionBudget,
+                embeddingContext
+        );
+    }
+
+    private List<RetrievedChunk> retrieveGlobalByModel(String question,
+                                                       List<String> collections,
+                                                       int budget,
+                                                       QueryEmbeddingContext embeddingContext) {
+        Map<String, List<String>> collectionsByModel = new LinkedHashMap<>();
+        for (String collection : collections) {
+            collectionsByModel.computeIfAbsent(
+                    embeddingContext.modelFor(collection),
+                    ignored -> new ArrayList<>()
+            ).add(collection);
+        }
+
+        List<RetrievedChunk> chunks = new ArrayList<>();
+        collectionsByModel.forEach((model, modelCollections) -> {
+            float[] vector = embeddingContext.vectorFor(question, modelCollections.get(0));
+            if (vector != null) {
+                chunks.addAll(retrieverService.retrieveGlobalByVector(vector, modelCollections, budget));
+            } else if (QueryEmbeddingContext.DEFAULT_MODEL_KEY.equals(model)) {
+                chunks.addAll(retrieverService.retrieveGlobal(question, modelCollections, budget));
+            } else {
+                log.error("全局检索缺少指定模型的预计算向量，跳过模型组: {}", model);
+            }
+        });
+        chunks.sort(Comparator.comparing(
+                RetrievedChunk::getScore,
+                Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        return chunks.stream().limit(budget).toList();
+    }
+
+    private QueryEmbeddingContext embeddingContext(SearchContext context) {
+        Object value = context.getMetadata().get(QueryEmbeddingContext.METADATA_KEY);
+        return value instanceof QueryEmbeddingContext embeddings
+                ? embeddings
+                : QueryEmbeddingContext.unavailable();
+    }
+
+    private List<String> plannedCollections(SearchContext context) {
+        Object value = context.getMetadata().get(PLANNED_COLLECTIONS_KEY);
+        if (!(value instanceof List<?> values)) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .toList();
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
@@ -82,6 +82,19 @@ public class MilvusVectorRetrieverService implements VectorRetrieverService {
         return searchShared(norm, filter, candidateBudget);
     }
 
+    @Override
+    public List<RetrievedChunk> retrieveGlobalByVector(float[] vector,
+                                                       List<String> collectionNames,
+                                                       int candidateBudget) {
+        if (collectionNames == null || collectionNames.isEmpty()) {
+            return List.of();
+        }
+        String inList = collectionNames.stream()
+                .map(c -> "\"" + c + "\"")
+                .collect(Collectors.joining(", "));
+        return searchShared(vector, "collection_name in [" + inList + "]", candidateBudget);
+    }
+
     /**
      * 在共享 collection 内执行一次向量检索
      *

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
@@ -66,6 +66,16 @@ public class PgVectorRetrieverService implements VectorRetrieverService {
         return queryByCollections(vector, collectionNames, candidateBudget);
     }
 
+    @Override
+    public List<RetrievedChunk> retrieveGlobalByVector(float[] vector,
+                                                       List<String> collectionNames,
+                                                       int candidateBudget) {
+        if (collectionNames == null || collectionNames.isEmpty()) {
+            return List.of();
+        }
+        return queryByCollections(vector, collectionNames, candidateBudget);
+    }
+
     /**
      * 在指定 collection 范围内执行一次向量相似度检索
      * <p>

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingBatcher.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingBatcher.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector;
+
+import cn.hutool.core.util.StrUtil;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.nageoffer.ai.ragent.infra.embedding.EmbeddingService;
+import com.nageoffer.ai.ragent.knowledge.dao.entity.KnowledgeBaseDO;
+import com.nageoffer.ai.ragent.knowledge.dao.mapper.KnowledgeBaseMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 请求级查询向量批处理器。
+ * <p>
+ * 先通过一次数据库查询获得目标 Collection 与嵌入模型的映射，再按模型分组调用批量向量化接口。
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueryEmbeddingBatcher {
+
+    private final KnowledgeBaseMapper knowledgeBaseMapper;
+    private final EmbeddingService embeddingService;
+
+    /**
+     * 为当前请求准备查询向量。
+     *
+     * @param scopedTasks    已明确 Collection 的检索任务
+     * @param globalQuestions 需要检索全部有效 Collection 的查询文本
+     */
+    public QueryEmbeddingContext prepare(List<SearchTask> scopedTasks, List<String> globalQuestions) {
+        List<SearchTask> safeTasks = scopedTasks == null ? List.of() : scopedTasks;
+        List<String> safeGlobalQuestions = globalQuestions == null ? List.of() : globalQuestions;
+        if (safeTasks.isEmpty() && safeGlobalQuestions.isEmpty()) {
+            return new QueryEmbeddingContext(true, Map.of(), Map.of(), Map.of());
+        }
+
+        List<KnowledgeBaseDO> knowledgeBases;
+        try {
+            var query = Wrappers.<KnowledgeBaseDO>query()
+                    .select("collection_name", "embedding_model")
+                    .eq("deleted", 0);
+            if (safeGlobalQuestions.isEmpty()) {
+                Set<String> collections = new LinkedHashSet<>();
+                for (SearchTask task : safeTasks) {
+                    if (task != null && StrUtil.isNotBlank(task.collectionName())) {
+                        collections.add(task.collectionName());
+                    }
+                }
+                if (collections.isEmpty()) {
+                    return new QueryEmbeddingContext(true, Map.of(), Map.of(), Map.of());
+                }
+                query.in("collection_name", collections);
+            }
+            knowledgeBases = knowledgeBaseMapper.selectList(query);
+        } catch (Exception e) {
+            log.error("批量读取 Collection 嵌入模型失败，回退到原有检索流程", e);
+            return QueryEmbeddingContext.unavailable();
+        }
+
+        Map<String, String> collectionModels = new LinkedHashMap<>();
+        for (KnowledgeBaseDO knowledgeBase : knowledgeBases) {
+            if (knowledgeBase == null || StrUtil.isBlank(knowledgeBase.getCollectionName())) {
+                continue;
+            }
+            collectionModels.put(
+                    knowledgeBase.getCollectionName(),
+                    modelKey(knowledgeBase.getEmbeddingModel())
+            );
+        }
+
+        Map<String, LinkedHashSet<String>> questionCollections = new LinkedHashMap<>();
+        for (SearchTask task : safeTasks) {
+            if (task == null || StrUtil.isBlank(task.question()) || StrUtil.isBlank(task.collectionName())) {
+                continue;
+            }
+            collectionModels.putIfAbsent(task.collectionName(), QueryEmbeddingContext.DEFAULT_MODEL_KEY);
+            questionCollections.computeIfAbsent(task.question(), ignored -> new LinkedHashSet<>())
+                    .add(task.collectionName());
+        }
+        for (String question : safeGlobalQuestions) {
+            if (StrUtil.isBlank(question)) {
+                continue;
+            }
+            questionCollections.computeIfAbsent(question, ignored -> new LinkedHashSet<>())
+                    .addAll(collectionModels.keySet());
+        }
+
+        Map<String, LinkedHashSet<String>> questionsByModel = new LinkedHashMap<>();
+        questionCollections.forEach((question, collections) -> collections.forEach(collection -> {
+            String model = collectionModels.getOrDefault(collection, QueryEmbeddingContext.DEFAULT_MODEL_KEY);
+            questionsByModel.computeIfAbsent(model, ignored -> new LinkedHashSet<>()).add(question);
+        }));
+
+        Map<QueryEmbeddingContext.VectorKey, float[]> vectors = new LinkedHashMap<>();
+        questionsByModel.forEach((model, questions) -> embedGroup(model, new ArrayList<>(questions), vectors));
+
+        Map<String, List<String>> immutableQuestionCollections = new LinkedHashMap<>();
+        questionCollections.forEach((question, collections) ->
+                immutableQuestionCollections.put(question, List.copyOf(collections)));
+        return new QueryEmbeddingContext(true, collectionModels, vectors, immutableQuestionCollections);
+    }
+
+    private void embedGroup(String model,
+                            List<String> questions,
+                            Map<QueryEmbeddingContext.VectorKey, float[]> vectors) {
+        try {
+            List<List<Float>> embeddings = QueryEmbeddingContext.DEFAULT_MODEL_KEY.equals(model)
+                    ? embeddingService.embedBatch(questions)
+                    : embeddingService.embedBatch(questions, model);
+            if (embeddings == null || embeddings.size() != questions.size()) {
+                log.error("批量向量化返回数量不匹配，model: {}, questions: {}, embeddings: {}",
+                        model, questions.size(), embeddings == null ? 0 : embeddings.size());
+                return;
+            }
+            for (int i = 0; i < questions.size(); i++) {
+                List<Float> embedding = embeddings.get(i);
+                if (embedding == null || embedding.isEmpty()) {
+                    continue;
+                }
+                vectors.put(
+                        new QueryEmbeddingContext.VectorKey(model, questions.get(i)),
+                        normalize(toArray(embedding))
+                );
+            }
+        } catch (Exception e) {
+            log.error("批量向量化失败，model: {}, questionCount: {}", model, questions.size(), e);
+        }
+    }
+
+    private String modelKey(String model) {
+        return StrUtil.isBlank(model) ? QueryEmbeddingContext.DEFAULT_MODEL_KEY : model.trim();
+    }
+
+    private float[] toArray(List<Float> values) {
+        float[] vector = new float[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            vector[i] = values.get(i);
+        }
+        return vector;
+    }
+
+    private float[] normalize(float[] vector) {
+        double sum = 0D;
+        for (float value : vector) {
+            sum += value * value;
+        }
+        double norm = Math.sqrt(sum);
+        if (norm == 0D) {
+            return vector;
+        }
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = (float) (vector[i] / norm);
+        }
+        return vector;
+    }
+}

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingContext.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 请求级查询向量上下文。
+ * <p>
+ * 向量以“模型 + 查询文本”为复用键，Collection 只负责映射到实际模型。
+ * 上下文仅在当前检索请求内共享，不做跨请求缓存。
+ */
+public final class QueryEmbeddingContext {
+
+    public static final String METADATA_KEY = QueryEmbeddingContext.class.getName();
+    public static final String DEFAULT_MODEL_KEY = "__default__";
+
+    private final boolean prepared;
+    private final Map<String, String> collectionModels;
+    private final Map<VectorKey, float[]> vectors;
+    private final Map<String, List<String>> questionCollections;
+
+    QueryEmbeddingContext(boolean prepared,
+                          Map<String, String> collectionModels,
+                          Map<VectorKey, float[]> vectors,
+                          Map<String, List<String>> questionCollections) {
+        this.prepared = prepared;
+        this.collectionModels = Map.copyOf(collectionModels);
+        this.vectors = Map.copyOf(vectors);
+        this.questionCollections = Map.copyOf(questionCollections);
+    }
+
+    public static QueryEmbeddingContext unavailable() {
+        return new QueryEmbeddingContext(false, Map.of(), Map.of(), Map.of());
+    }
+
+    public boolean isPrepared() {
+        return prepared;
+    }
+
+    public List<String> collectionsFor(String question) {
+        return questionCollections.getOrDefault(question, List.of());
+    }
+
+    public String modelFor(String collectionName) {
+        return collectionModels.getOrDefault(collectionName, DEFAULT_MODEL_KEY);
+    }
+
+    public boolean usesDefaultModel(String collectionName) {
+        return DEFAULT_MODEL_KEY.equals(modelFor(collectionName));
+    }
+
+    public float[] vectorFor(String question, String collectionName) {
+        float[] vector = vectors.get(new VectorKey(modelFor(collectionName), question));
+        return vector == null ? null : vector.clone();
+    }
+
+    record VectorKey(String model, String question) {
+    }
+}

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/SearchTask.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/SearchTask.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector;
+
+/**
+ * 一次向量检索需要的查询文本与目标 Collection。
+ *
+ * @param question       查询文本
+ * @param collectionName 目标 Collection
+ */
+public record SearchTask(String question, String collectionName) {
+}

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
@@ -20,6 +20,8 @@ package com.nageoffer.ai.ragent.rag.core.vector;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -125,6 +127,31 @@ public interface VectorRetrieverService {
      */
     default List<RetrievedChunk> retrieveGlobal(String query, List<String> collectionNames, int candidateBudget) {
         throw new UnsupportedOperationException("该检索后端不支持单次全局检索");
+    }
+
+    /**
+     * 使用预计算向量执行跨库检索。
+     * <p>
+     * 默认实现逐库检索并合并，支持单次跨库查询的后端应覆盖此方法。
+     */
+    default List<RetrievedChunk> retrieveGlobalByVector(float[] vector,
+                                                        List<String> collectionNames,
+                                                        int candidateBudget) {
+        List<RetrievedChunk> chunks = new ArrayList<>();
+        for (String collectionName : collectionNames) {
+            chunks.addAll(retrieveByVector(
+                    vector,
+                    RetrieveRequest.builder()
+                            .collectionName(collectionName)
+                            .topK(candidateBudget)
+                            .build()
+            ));
+        }
+        chunks.sort(Comparator.comparing(
+                RetrievedChunk::getScore,
+                Comparator.nullsLast(Comparator.reverseOrder())
+        ));
+        return chunks.stream().limit(candidateBudget).toList();
     }
 }
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetriever.java
@@ -19,8 +19,8 @@ package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.vector.QueryEmbeddingContext;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
-import com.nageoffer.ai.ragent.rag.core.vector.strategy.AbstractParallelRetriever;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.concurrent.Executor;
  * 继承模板类，实现 Collection 特定的检索逻辑
  */
 @Slf4j
-public class CollectionParallelRetriever extends AbstractParallelRetriever<String> {
+public class CollectionParallelRetriever extends AbstractParallelRetriever<CollectionParallelRetriever.CollectionTask> {
 
     private final VectorRetrieverService retrieverService;
 
@@ -40,25 +40,52 @@ public class CollectionParallelRetriever extends AbstractParallelRetriever<Strin
         this.retrieverService = retrieverService;
     }
 
+    public record CollectionTask(String collectionName, float[] queryVector, boolean defaultModel) {
+    }
+
+    public List<RetrievedChunk> retrieveByCollections(String question,
+                                                      List<String> collections,
+                                                      int topK,
+                                                      QueryEmbeddingContext embeddingContext) {
+        List<CollectionTask> tasks = collections.stream()
+                .map(collection -> new CollectionTask(
+                        collection,
+                        embeddingContext != null && embeddingContext.isPrepared()
+                                ? embeddingContext.vectorFor(question, collection)
+                                : null,
+                        embeddingContext == null
+                                || !embeddingContext.isPrepared()
+                                || embeddingContext.usesDefaultModel(collection)
+                ))
+                .toList();
+        return super.executeParallelRetrieval(question, tasks, topK);
+    }
+
     @Override
-    protected List<RetrievedChunk> createRetrievalTask(String question, String collectionName, int topK) {
+    protected List<RetrievedChunk> createRetrievalTask(String question, CollectionTask task, int topK) {
         try {
-            return retrieverService.retrieve(
-                    RetrieveRequest.builder()
-                            .collectionName(collectionName)
-                            .query(question)
-                            .topK(topK)
-                            .build()
-            );
+            RetrieveRequest request = RetrieveRequest.builder()
+                    .collectionName(task.collectionName())
+                    .query(question)
+                    .topK(topK)
+                    .build();
+            if (task.queryVector() != null) {
+                return retrieverService.retrieveByVector(task.queryVector(), request);
+            }
+            if (task.defaultModel()) {
+                return retrieverService.retrieve(request);
+            }
+            log.error("全局检索缺少指定模型的预计算向量，跳过 Collection: {}", task.collectionName());
+            return List.of();
         } catch (Exception e) {
-            log.error("在 collection {} 中检索失败，错误: {}", collectionName, e.getMessage(), e);
+            log.error("在 collection {} 中检索失败，错误: {}", task.collectionName(), e.getMessage(), e);
             return List.of();
         }
     }
 
     @Override
-    protected String getTargetIdentifier(String collectionName) {
-        return "Collection: " + collectionName;
+    protected String getTargetIdentifier(CollectionTask task) {
+        return "Collection: " + task.collectionName();
     }
 
     @Override

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
@@ -21,8 +21,8 @@ import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.vector.QueryEmbeddingContext;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
-import com.nageoffer.ai.ragent.rag.core.vector.strategy.AbstractParallelRetriever;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -37,7 +37,7 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
 
     private final VectorRetrieverService retrieverService;
 
-    public record IntentTask(NodeScore nodeScore, int intentTopK) {
+    public record IntentTask(NodeScore nodeScore, int intentTopK, float[] queryVector, boolean defaultModel) {
     }
 
     public IntentParallelRetriever(VectorRetrieverService retrieverService,
@@ -52,12 +52,22 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
      */
     public List<RetrievedChunk> retrieveByIntents(String question,
                                                   List<NodeScore> targets,
-                                                  int recallBudget) {
+                                                  int recallBudget,
+                                                  QueryEmbeddingContext embeddingContext) {
         List<IntentTask> intentTasks = targets.stream()
-                .map(nodeScore -> new IntentTask(
-                        nodeScore,
-                        resolveIntentTopK(nodeScore, recallBudget)
-                ))
+                .map(nodeScore -> {
+                    String collectionName = nodeScore.getNode().getCollectionName();
+                    return new IntentTask(
+                            nodeScore,
+                            resolveIntentTopK(nodeScore, recallBudget),
+                            embeddingContext != null && embeddingContext.isPrepared()
+                                    ? embeddingContext.vectorFor(question, collectionName)
+                                    : null,
+                            embeddingContext == null
+                                    || !embeddingContext.isPrepared()
+                                    || embeddingContext.usesDefaultModel(collectionName)
+                    );
+                })
                 .toList();
         return super.executeParallelRetrieval(question, intentTasks, recallBudget);
     }
@@ -67,13 +77,19 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
         NodeScore nodeScore = task.nodeScore();
         IntentNode node = nodeScore.getNode();
         try {
-            return retrieverService.retrieve(
-                    RetrieveRequest.builder()
-                            .collectionName(node.getCollectionName())
-                            .query(question)
-                            .topK(task.intentTopK())
-                            .build()
-            );
+            RetrieveRequest request = RetrieveRequest.builder()
+                    .collectionName(node.getCollectionName())
+                    .query(question)
+                    .topK(task.intentTopK())
+                    .build();
+            if (task.queryVector() != null) {
+                return retrieverService.retrieveByVector(task.queryVector(), request);
+            }
+            if (task.defaultModel()) {
+                return retrieverService.retrieve(request);
+            }
+            log.error("意图检索缺少指定模型的预计算向量，跳过 Collection: {}", node.getCollectionName());
+            return List.of();
         } catch (Exception e) {
             log.error("意图检索失败 - 意图ID: {}, 意图名称: {}, Collection: {}, 错误: {}",
                     node.getId(), node.getName(), node.getCollectionName(), e.getMessage(), e);

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingBatcherTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/QueryEmbeddingBatcherTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector;
+
+import com.nageoffer.ai.ragent.infra.embedding.EmbeddingService;
+import com.nageoffer.ai.ragent.knowledge.dao.entity.KnowledgeBaseDO;
+import com.nageoffer.ai.ragent.knowledge.dao.mapper.KnowledgeBaseMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QueryEmbeddingBatcherTest {
+
+    private KnowledgeBaseMapper knowledgeBaseMapper;
+    private EmbeddingService embeddingService;
+    private QueryEmbeddingBatcher batcher;
+
+    @BeforeEach
+    void setUp() {
+        knowledgeBaseMapper = mock(KnowledgeBaseMapper.class);
+        embeddingService = mock(EmbeddingService.class);
+        batcher = new QueryEmbeddingBatcher(knowledgeBaseMapper, embeddingService);
+    }
+
+    @Test
+    void shouldQueryCollectionModelsOnceAndReuseOneBatchForSameModel() {
+        when(knowledgeBaseMapper.selectList(any())).thenReturn(List.of(
+                knowledgeBase("collection-a", "model-a"),
+                knowledgeBase("collection-b", "model-a")
+        ));
+        when(embeddingService.embedBatch(List.of("question"), "model-a"))
+                .thenReturn(List.of(List.of(3F, 4F)));
+
+        QueryEmbeddingContext context = batcher.prepare(
+                List.of(
+                        new SearchTask("question", "collection-a"),
+                        new SearchTask("question", "collection-b")
+                ),
+                List.of()
+        );
+
+        verify(knowledgeBaseMapper).selectList(any());
+        verify(embeddingService).embedBatch(List.of("question"), "model-a");
+        assertThat(context.vectorFor("question", "collection-a")).containsExactly(0.6F, 0.8F);
+        assertThat(context.vectorFor("question", "collection-b")).containsExactly(0.6F, 0.8F);
+    }
+
+    @Test
+    void shouldBatchUniqueQuestionsPerActualModelAndUseDefaultRouteForBlankModel() {
+        when(knowledgeBaseMapper.selectList(any())).thenReturn(List.of(
+                knowledgeBase("collection-a", "model-a"),
+                knowledgeBase("collection-default", " ")
+        ));
+        when(embeddingService.embedBatch(List.of("question-1", "question-2"), "model-a"))
+                .thenReturn(List.of(List.of(1F, 0F), List.of(0F, 2F)));
+        when(embeddingService.embedBatch(List.of("question-1")))
+                .thenReturn(List.of(List.of(0F, 3F)));
+
+        QueryEmbeddingContext context = batcher.prepare(
+                List.of(
+                        new SearchTask("question-1", "collection-a"),
+                        new SearchTask("question-1", "collection-default"),
+                        new SearchTask("question-2", "collection-a")
+                ),
+                List.of()
+        );
+
+        verify(knowledgeBaseMapper).selectList(any());
+        verify(embeddingService).embedBatch(List.of("question-1", "question-2"), "model-a");
+        verify(embeddingService).embedBatch(List.of("question-1"));
+        assertThat(context.modelFor("collection-default"))
+                .isEqualTo(QueryEmbeddingContext.DEFAULT_MODEL_KEY);
+        assertThat(context.vectorFor("question-2", "collection-a")).containsExactly(0F, 1F);
+        assertThat(context.vectorFor("question-1", "collection-default")).containsExactly(0F, 1F);
+    }
+
+    @Test
+    void shouldExpandGlobalQuestionToCollectionsFromSameMetadataQuery() {
+        when(knowledgeBaseMapper.selectList(any())).thenReturn(List.of(
+                knowledgeBase("collection-a", "model-a"),
+                knowledgeBase("collection-b", "model-b")
+        ));
+        when(embeddingService.embedBatch(List.of("global-question"), "model-a"))
+                .thenReturn(List.of(List.of(1F)));
+        when(embeddingService.embedBatch(List.of("global-question"), "model-b"))
+                .thenReturn(List.of(List.of(2F)));
+
+        QueryEmbeddingContext context = batcher.prepare(List.of(), List.of("global-question"));
+
+        verify(knowledgeBaseMapper).selectList(any());
+        assertThat(context.collectionsFor("global-question"))
+                .containsExactly("collection-a", "collection-b");
+        assertThat(context.vectorFor("global-question", "collection-a")).containsExactly(1F);
+        assertThat(context.vectorFor("global-question", "collection-b")).containsExactly(1F);
+    }
+
+    @Test
+    void shouldNotFallBackToDefaultModelWhenExplicitModelBatchFails() {
+        when(knowledgeBaseMapper.selectList(any())).thenReturn(List.of(
+                knowledgeBase("collection-a", "model-a")
+        ));
+        when(embeddingService.embedBatch(List.of("question"), "model-a"))
+                .thenThrow(new IllegalStateException("remote error"));
+
+        QueryEmbeddingContext context = batcher.prepare(
+                List.of(new SearchTask("question", "collection-a")),
+                List.of()
+        );
+
+        assertThat(context.isPrepared()).isTrue();
+        assertThat(context.vectorFor("question", "collection-a")).isNull();
+        verify(embeddingService, never()).embedBatch(List.of("question"));
+    }
+
+    private KnowledgeBaseDO knowledgeBase(String collection, String model) {
+        return KnowledgeBaseDO.builder()
+                .collectionName(collection)
+                .embeddingModel(model)
+                .build();
+    }
+}


### PR DESCRIPTION
## 修改内容

- 在子问题并行检索前，先构建当前请求的全部检索上下文；
- 每个请求集中查询一次目标 Collection 与 Embedding 模型的映射；
- 按 `(embeddingModel, question)` 去重，每个模型组调用一次 `embedBatch(...)`；
- 通过请求级上下文共享归一化后的 Query Vector，不增加跨请求缓存；
- 意图检索、Collection fan-out、PG 全局检索和 Milvus 全局检索优先使用预计算向量。

## 问题原因

原检索链路可能在同一请求包含多个子问题或命中多个 Collection 时，重复计算内容相同的 Query Embedding。每次计算都需要访问远程向量化模型，会增加不必要的网络 IO 和检索延迟。

本次修改将 Query Embedding 准备前置到子问题并行检索之前。Collection 未配置 `embeddingModel` 时继续使用系统默认向量化路由；显式配置模型时调用 `embedBatch(questions, modelId)`。

## 行为边界

- Collection 与模型的映射每个请求集中查询一次；
- 相同模型下的重复问题只计算一次 Query Embedding；
- Query Vector 只在当前请求内复用；
- 向量数据库查询次数仍由检索作用域和后端能力决定，不会将所有向量查询强制合并；
- 使用同一模型时，PG/Milvus 的全局检索仍保持每个子问题一次跨 Collection 向量查询；
- 不同模型不能共享同一个 Query Vector，当前会按模型组分别准备向量和执行对应查询。

## 异常降级

- Collection 模型映射查询失败时，回退到原有默认模型检索流程；
- 默认模型批量向量化失败时，保留原有检索降级入口；
- 显式模型向量化失败时跳过对应模型组，避免静默使用错误的默认模型向量。

## 验证结果

```text
mvn -pl bootstrap -am "-Dtest=QueryEmbeddingBatcherTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

mvn -pl bootstrap -am -DskipTests compile
BUILD SUCCESS

git diff --check
通过
```

Closes #58
