### PR TITLE
修复文件上传触发防重复摘要栈溢出

### DIFF
--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/idempotent/IdempotentSubmitAspect.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/idempotent/IdempotentSubmitAspect.java
@@ -20,6 +20,9 @@ package com.nageoffer.ai.ragent.framework.idempotent;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.digest.DigestUtil;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializer;
 import com.nageoffer.ai.ragent.framework.context.UserContext;
 import com.nageoffer.ai.ragent.framework.exception.ClientException;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +36,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
@@ -47,7 +51,18 @@ import java.util.Objects;
 public final class IdempotentSubmitAspect {
 
     private final RedissonClient redissonClient;
-    private final Gson gson = new Gson();
+    private final Gson gson = new GsonBuilder()
+            .registerTypeHierarchyAdapter(
+                    MultipartFile.class,
+                    (JsonSerializer<MultipartFile>) (file, type, context) -> {
+                        JsonObject json = new JsonObject();
+                        json.addProperty("name", file.getName());
+                        json.addProperty("originalFilename", file.getOriginalFilename());
+                        json.addProperty("contentType", file.getContentType());
+                        json.addProperty("size", file.getSize());
+                        return json;
+                    })
+            .create();
 
     @Value("${app.eval.enabled:false}")
     private boolean evalEnabled;

--- a/framework/src/test/java/com/nageoffer/ai/ragent/framework/idempotent/IdempotentSubmitAspectTest.java
+++ b/framework/src/test/java/com/nageoffer/ai/ragent/framework/idempotent/IdempotentSubmitAspectTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.framework.idempotent;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IdempotentSubmitAspectTest {
+
+    @Test
+    void shouldGenerateDigestFromMultipartMetadataWithoutReadingContent() throws Exception {
+        byte[] firstContent = new byte[20 * 1024 * 1024];
+        byte[] differentContent = firstContent.clone();
+        differentContent[differentContent.length - 1] = 1;
+        MockMultipartFile first = new MockMultipartFile("file", "first.pdf", "application/pdf", firstContent);
+        MockMultipartFile sameMetadata =
+                new MockMultipartFile("file", "first.pdf", "application/pdf", differentContent);
+        MockMultipartFile differentName =
+                new MockMultipartFile("file", "second.pdf", "application/pdf", firstContent);
+
+        assertEquals(calcArgsMd5(first), calcArgsMd5(sameMetadata));
+        assertNotEquals(calcArgsMd5(first), calcArgsMd5(differentName));
+    }
+
+    private String calcArgsMd5(MockMultipartFile file) throws Exception {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{file});
+        IdempotentSubmitAspect aspect = new IdempotentSubmitAspect(mock(RedissonClient.class));
+        Method method = IdempotentSubmitAspect.class.getDeclaredMethod("calcArgsMD5", ProceedingJoinPoint.class);
+        method.setAccessible(true);
+        return (String) method.invoke(aspect, joinPoint);
+    }
+}


### PR DESCRIPTION
## 修改内容

- 为 `MultipartFile` 注册 Gson 层级序列化适配器
- 生成防重复摘要时仅保留字段名、原始文件名、内容类型和文件大小
- 避免递归序列化 Multipart 实现及读取文件字节
- 增加 20MB 文件回归测试，覆盖不同文件内容不参与摘要、文件名仍参与摘要的行为

## 问题原因

`IdempotentSubmitAspect` 默认通过 `gson.toJson(joinPoint.getArgs())` 生成请求参数摘要。请求参数包含 `MultipartFile` 时，Gson 会继续序列化其具体实现，可能递归进入底层请求结构或处理大块文件内容，最终导致栈溢出或不必要的内存开销。

## 影响

普通请求参数的摘要逻辑保持不变。文件上传请求不再读取文件字节；同一用户、请求路径以及文件元数据相同的并发提交仍会命中同一个防重复 Key。

## 验证

```shell
mvn -pl framework -am "-DskipTests=false" "-Dtest=IdempotentSubmitAspectTest" "-Dsurefire.failIfNoSpecifiedTests=false" test
```

测试结果：1 个测试通过，无失败或错误。
