### PR TITLE
fix(ingestion): 正确解析任务元数据与节点输出 JSON

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImpl.java
@@ -17,7 +17,6 @@
 
 package com.nageoffer.ai.ragent.ingestion.service.impl;
 
-import cn.hutool.core.bean.BeanUtil;
 import cn.hutool.core.lang.Assert;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -368,7 +367,7 @@ public class IngestionTaskServiceImpl implements IngestionTaskService {
                 .chunkCount(task.getChunkCount())
                 .errorMessage(task.getErrorMessage())
                 .logs(readLogs(task.getLogsJson()))
-                .metadata(BeanUtil.beanToMap(task.getMetadataJson()))
+                .metadata(readMap(task.getMetadataJson()))
                 .startedAt(task.getStartedAt())
                 .completedAt(task.getCompletedAt())
                 .createdBy(task.getCreatedBy())
@@ -389,7 +388,7 @@ public class IngestionTaskServiceImpl implements IngestionTaskService {
                 .durationMs(node.getDurationMs())
                 .message(node.getMessage())
                 .errorMessage(node.getErrorMessage())
-                .output(BeanUtil.beanToMap(node.getOutputJson()))
+                .output(readMap(node.getOutputJson()))
                 .createTime(node.getCreateTime())
                 .updateTime(node.getUpdateTime())
                 .build();
@@ -403,6 +402,19 @@ public class IngestionTaskServiceImpl implements IngestionTaskService {
             return objectMapper.writeValueAsString(value);
         } catch (Exception e) {
             return null;
+        }
+    }
+
+    private Map<String, Object> readMap(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return Map.of();
+        }
+        try {
+            Map<String, Object> value = objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {
+            });
+            return value == null ? Map.of() : value;
+        } catch (Exception e) {
+            return Map.of();
         }
     }
 

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImplTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImplTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.ingestion.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.audit.support.BizChangeLogContext;
+import com.nageoffer.ai.ragent.ingestion.controller.vo.IngestionTaskNodeVO;
+import com.nageoffer.ai.ragent.ingestion.controller.vo.IngestionTaskVO;
+import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionTaskDO;
+import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionTaskNodeDO;
+import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionTaskMapper;
+import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionTaskNodeMapper;
+import com.nageoffer.ai.ragent.ingestion.engine.IngestionEngine;
+import com.nageoffer.ai.ragent.ingestion.service.IngestionPipelineService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IngestionTaskServiceImplTest {
+
+    @Mock
+    private IngestionEngine engine;
+
+    @Mock
+    private IngestionPipelineService pipelineService;
+
+    @Mock
+    private IngestionTaskMapper taskMapper;
+
+    @Mock
+    private IngestionTaskNodeMapper taskNodeMapper;
+
+    @Mock
+    private BizChangeLogContext bizChangeLogContext;
+
+    private IngestionTaskServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IngestionTaskServiceImpl(
+                engine,
+                pipelineService,
+                taskMapper,
+                taskNodeMapper,
+                new ObjectMapper(),
+                bizChangeLogContext
+        );
+    }
+
+    @Test
+    void getParsesMetadataJsonInsteadOfTreatingItAsABean() {
+        IngestionTaskDO task = IngestionTaskDO.builder()
+                .id("task-1")
+                .pipelineId("pipeline-1")
+                .metadataJson("{\"keywords\":[\"rag\",\"agent\"],\"stats\":{\"chunks\":3}}")
+                .build();
+        when(taskMapper.selectById("task-1")).thenReturn(task);
+
+        IngestionTaskVO result = service.get("task-1");
+
+        assertEquals(List.of("rag", "agent"), result.getMetadata().get("keywords"));
+        Map<?, ?> stats = (Map<?, ?>) result.getMetadata().get("stats");
+        assertEquals(3, ((Number) stats.get("chunks")).intValue());
+    }
+
+    @Test
+    void listNodesParsesNestedOutputJson() {
+        IngestionTaskNodeDO node = IngestionTaskNodeDO.builder()
+                .id("node-record-1")
+                .taskId("task-1")
+                .pipelineId("pipeline-1")
+                .nodeId("fetcher-1")
+                .outputJson("{\"rawBytesLength\":128,\"source\":{\"type\":\"file\"}}")
+                .build();
+        when(taskNodeMapper.selectList(any())).thenReturn(List.of(node));
+
+        List<IngestionTaskNodeVO> result = service.listNodes("task-1");
+
+        assertEquals(128, ((Number) result.get(0).getOutput().get("rawBytesLength")).intValue());
+        Map<?, ?> source = (Map<?, ?>) result.get(0).getOutput().get("source");
+        assertEquals("file", source.get("type"));
+    }
+
+    @Test
+    void invalidOrBlankJsonFallsBackToEmptyMaps() {
+        IngestionTaskDO task = IngestionTaskDO.builder()
+                .id("task-1")
+                .pipelineId("pipeline-1")
+                .metadataJson("{invalid")
+                .build();
+        IngestionTaskNodeDO node = IngestionTaskNodeDO.builder()
+                .id("node-record-1")
+                .taskId("task-1")
+                .pipelineId("pipeline-1")
+                .nodeId("fetcher-1")
+                .outputJson(" ")
+                .build();
+        when(taskMapper.selectById("task-1")).thenReturn(task);
+        when(taskNodeMapper.selectList(any())).thenReturn(List.of(node));
+
+        assertTrue(service.get("task-1").getMetadata().isEmpty());
+        assertTrue(service.listNodes("task-1").get(0).getOutput().isEmpty());
+
+        task.setMetadataJson("null");
+        assertTrue(service.get("task-1").getMetadata().isEmpty());
+    }
+}


### PR DESCRIPTION
## 问题

任务详情和节点列表会把数据库中的 `metadataJson`、`outputJson` 作为 JSON 字符串读取，但转换 VO 时使用 `BeanUtil.beanToMap(...)` 处理字符串。

合法 JSON 因此会被转换为空对象，管理端无法看到任务 metadata 和节点 output 的真实结构。

## 根因

`BeanUtil.beanToMap` 用于读取 Java Bean 属性，不会把 JSON 字符串解析为对象结构。数据库字段的实际类型与转换方式不匹配。

## 修复

- 使用项目已有 `ObjectMapper` 将 JSON 对象解析为 `Map<String, Object>`；
- 保留嵌套对象和数组结构；
- 空字符串、JSON `null` 或非法 JSON 继续安全降级为空 Map；
- 不修改数据库结构、接口字段或任务写入流程。

## 验证

新增单元测试覆盖：

- 任务 metadata 的数组和嵌套对象；
- 节点 output 的嵌套结构；
- 非法、空白和 JSON `null` 的容错行为。

```bash
./mvnw -pl bootstrap -am test -Dtest=IngestionTaskServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 3, Failures: 0, Errors: 0, Skipped: 0

./mvnw spotless:check
# BUILD SUCCESS
```
