### PR TITLE
fix(ingestion): 让非法数值条件安全返回 false

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluator.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluator.java
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.IntPredicate;
 
 /**
  * 条件评估器
@@ -122,10 +123,10 @@ public class ConditionEvaluator {
             case "in" -> in(left, right);
             case "contains" -> contains(left, right);
             case "regex" -> regex(left, right);
-            case "gt" -> compareNumber(left, right) > 0;
-            case "gte" -> compareNumber(left, right) >= 0;
-            case "lt" -> compareNumber(left, right) < 0;
-            case "lte" -> compareNumber(left, right) <= 0;
+            case "gt" -> compareNumbers(left, right, result -> result > 0);
+            case "gte" -> compareNumbers(left, right, result -> result >= 0);
+            case "lt" -> compareNumbers(left, right, result -> result < 0);
+            case "lte" -> compareNumbers(left, right, result -> result <= 0);
             case "exists" -> left != null;
             case "not_exists" -> left == null;
             default -> Objects.equals(normalize(left), normalize(right));
@@ -162,27 +163,27 @@ public class ConditionEvaluator {
         return String.valueOf(left).matches(String.valueOf(right));
     }
 
-    private int compareNumber(Object left, Object right) {
-        if (left == null || right == null) {
-            return 0;
-        }
+    private boolean compareNumbers(Object left, Object right, IntPredicate predicate) {
         Double l = toDouble(left);
         Double r = toDouble(right);
         if (l == null || r == null) {
-            return 0;
+            return false;
         }
-        return Double.compare(l, r);
+        return predicate.test(Double.compare(l, r));
     }
 
     private Double toDouble(Object value) {
+        Double number;
         if (value instanceof Number n) {
-            return n.doubleValue();
+            number = n.doubleValue();
+        } else {
+            try {
+                number = Double.parseDouble(String.valueOf(value));
+            } catch (Exception e) {
+                return null;
+            }
         }
-        try {
-            return Double.parseDouble(String.valueOf(value));
-        } catch (Exception e) {
-            return null;
-        }
+        return Double.isFinite(number) ? number : null;
     }
 
     private Object normalize(Object value) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluatorTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluatorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.ingestion.engine;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.nageoffer.ai.ragent.ingestion.domain.context.IngestionContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ConditionEvaluatorTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ConditionEvaluator evaluator = new ConditionEvaluator(objectMapper);
+
+    @Test
+    void missingNestedFieldDoesNotMatchInclusiveCondition() {
+        IngestionContext context = IngestionContext.builder()
+                .metadata(Map.of())
+                .build();
+        ObjectNode rule = objectMapper.createObjectNode()
+                .put("field", "metadata.score")
+                .put("operator", "gte")
+                .put("value", 10);
+
+        assertFalse(evaluator.evaluate(context, rule));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidNumericOperands")
+    void invalidNumericOperandsNeverMatch(String left, String operator, Object right) {
+        IngestionContext context = IngestionContext.builder()
+                .rawText(left)
+                .build();
+
+        assertFalse(evaluator.evaluate(context, numericRule(operator, right)));
+    }
+
+    static Stream<Arguments> invalidNumericOperands() {
+        return Stream.of(
+                arguments(null, "gt", 10),
+                arguments(null, "gte", 10),
+                arguments(null, "lt", 10),
+                arguments(null, "lte", 10),
+                arguments("not-a-number", "gt", 10),
+                arguments("not-a-number", "gte", 10),
+                arguments("not-a-number", "lt", 10),
+                arguments("not-a-number", "lte", 10),
+                arguments("10", "gt", "not-a-number"),
+                arguments("10", "gte", "not-a-number"),
+                arguments("10", "lt", "not-a-number"),
+                arguments("10", "lte", "not-a-number"),
+                arguments("10", "gt", null),
+                arguments("10", "gte", null),
+                arguments("10", "lt", null),
+                arguments("10", "lte", null),
+                arguments("NaN", "gt", 10),
+                arguments("NaN", "gte", 10),
+                arguments("NaN", "lt", 10),
+                arguments("NaN", "lte", 10),
+                arguments("Infinity", "gt", 10),
+                arguments("Infinity", "gte", 10),
+                arguments("Infinity", "lt", 10),
+                arguments("Infinity", "lte", 10)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "11, gt, 10, true",
+            "10, gt, 10, false",
+            "10, gte, 10, true",
+            "9.5, gte, 10, false",
+            "9.5, lt, 10, true",
+            "10, lt, 10, false",
+            "10, lte, 10, true",
+            "11, lte, 10, false"
+    })
+    void validNumericOperandsKeepComparisonSemantics(
+            String left, String operator, double right, boolean expected) {
+        IngestionContext context = IngestionContext.builder()
+                .rawText(left)
+                .build();
+
+        assertEquals(expected, evaluator.evaluate(context, numericRule(operator, right)));
+    }
+
+    private ObjectNode numericRule(String operator, Object right) {
+        ObjectNode rule = objectMapper.createObjectNode()
+                .put("field", "rawText")
+                .put("operator", operator);
+        rule.set("value", objectMapper.valueToTree(right));
+        return rule;
+    }
+}


### PR DESCRIPTION
## 问题

Pipeline 数值条件在字段缺失或数值转换失败时，会让 `compareNumber(...)` 返回 `0`。

`gte` 和 `lte` 随后把该占位值当作真实比较结果，导致非法条件错误命中并放行对应节点。

## 根因

当前实现用同一个整数值同时表达“两个数相等”和“无法比较”，丢失了转换失败状态。

## 修复

- 仅在左右两侧都能转换为有限数值时执行比较；
- 缺失字段、空值、非法字符串、`NaN` 和 `Infinity` 统一返回 `false`；
- 保持正常 `gt/gte/lt/lte` 的边界语义不变。

这里选择 fail-closed，是为了避免错误配置或异常数据触发本不应该执行的 Pipeline 节点。现有表达式求值失败路径同样采用返回 `false` 的容错策略。

## 验证

```bash
./mvnw -pl bootstrap -am test -Dtest=ConditionEvaluatorTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 33, Failures: 0, Errors: 0, Skipped: 0

./mvnw spotless:check
# BUILD SUCCESS
```

测试覆盖缺失字段、两侧非法输入、空值、`NaN`、`Infinity` 以及正常相等和大小边界。

Fixes #72
