### PR TITLE
fix(intent): 空意图树跳过 LLM 分类调用

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/intent/DefaultIntentClassifier.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/intent/DefaultIntentClassifier.java
@@ -138,6 +138,10 @@ public class DefaultIntentClassifier implements IntentClassifier, IntentNodeRegi
     public List<NodeScore> classifyTargets(String question) {
         // 每次都从Redis读取最新数据
         IntentTreeData data = loadIntentTreeData();
+        if (data.leafNodes.isEmpty()) {
+            log.debug("意图树没有可用叶子节点，跳过 LLM 意图识别");
+            return List.of();
+        }
 
         String systemPrompt = buildPrompt(data.leafNodes);
         ChatRequest request = ChatRequest.builder()

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/intent/DefaultIntentClassifierTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/intent/DefaultIntentClassifierTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.intent;
+
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import com.nageoffer.ai.ragent.rag.dao.mapper.IntentNodeMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultIntentClassifierTest {
+
+    @Mock
+    private LLMService llmService;
+
+    @Mock
+    private IntentNodeMapper intentNodeMapper;
+
+    @Mock
+    private PromptTemplateLoader promptTemplateLoader;
+
+    @Mock
+    private IntentTreeCacheManager intentTreeCacheManager;
+
+    private DefaultIntentClassifier classifier;
+
+    @BeforeEach
+    void setUp() {
+        classifier = new DefaultIntentClassifier(
+                llmService,
+                intentNodeMapper,
+                promptTemplateLoader,
+                intentTreeCacheManager
+        );
+    }
+
+    @Test
+    void skipsLlmWhenIntentTreeIsEmpty() {
+        when(intentTreeCacheManager.getIntentTreeFromCache()).thenReturn(List.of());
+        when(intentNodeMapper.selectList(any())).thenReturn(List.of());
+
+        List<NodeScore> scores = classifier.classifyTargets("How do I apply for leave?");
+
+        assertTrue(scores.isEmpty());
+        verifyNoInteractions(llmService, promptTemplateLoader);
+    }
+}


### PR DESCRIPTION
## 问题

当意图树没有任何可用叶子节点时，`DefaultIntentClassifier#classifyTargets` 仍会构建一个没有候选目标的 Prompt 并调用 LLM。

新部署、尚未配置意图树或清空意图配置后，每个聊天子问题都会产生一次没有业务收益的模型调用。

## 根因

分类器已经能把空缓存和空数据库转换为空 `IntentTreeData`，但分类入口没有在 `leafNodes` 为空时提前返回。

## 修复

- 加载意图树后检查叶子节点；
- 没有候选叶子节点时直接返回既有的空意图兜底；
- 不构建 Prompt，不调用 LLM；
- 不修改意图树缓存、初始化或下游降级策略。

## 验证

新增单元测试模拟缓存和数据库均为空，断言结果为空，并验证 `PromptTemplateLoader` 和 `llmService` 均未发生交互。

```bash
./mvnw -pl bootstrap -am test -Dtest=DefaultIntentClassifierTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

./mvnw spotless:check
# BUILD SUCCESS
```

Fixes #73
