### PR TITLE
optimize(rag): 复用并行检索 Query Embedding

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
@@ -50,7 +50,7 @@ public class MilvusVectorRetrieverService implements VectorRetrieverService {
 
     @Override
     public List<RetrievedChunk> retrieve(RetrieveRequest retrieveParam) {
-        float[] norm = normalize(toArray(embeddingService.embed(retrieveParam.getQuery())));
+        float[] norm = embedAndNormalize(retrieveParam.getQuery());
         return retrieveByVector(norm, retrieveParam);
     }
 
@@ -76,7 +76,7 @@ public class MilvusVectorRetrieverService implements VectorRetrieverService {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
         }
-        float[] norm = normalize(toArray(embeddingService.embed(query)));
+        float[] norm = embedAndNormalize(query);
         // 全局检索：单次在共享 collection 内按 collection_name in [...] 跨库召回，替代逐库 fan-out
         String filter = buildCollectionFilter(collectionNames);
         return searchShared(norm, filter, candidateBudget);

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/MilvusVectorRetrieverService.java
@@ -62,6 +62,11 @@ public class MilvusVectorRetrieverService implements VectorRetrieverService {
     }
 
     @Override
+    public float[] embedAndNormalize(String query) {
+        return normalize(toArray(embeddingService.embed(query)));
+    }
+
+    @Override
     public boolean supportsGlobalRetrieval() {
         return true;
     }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
@@ -55,6 +55,11 @@ public class PgVectorRetrieverService implements VectorRetrieverService {
     }
 
     @Override
+    public float[] embedAndNormalize(String query) {
+        return normalize(toArray(embeddingService.embed(query)));
+    }
+
+    @Override
     public boolean supportsGlobalRetrieval() {
         return true;
     }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/PgVectorRetrieverService.java
@@ -39,8 +39,7 @@ public class PgVectorRetrieverService implements VectorRetrieverService {
 
     @Override
     public List<RetrievedChunk> retrieve(RetrieveRequest request) {
-        List<Float> embedding = embeddingService.embed(request.getQuery());
-        float[] vector = normalize(toArray(embedding));
+        float[] vector = embedAndNormalize(request.getQuery());
         return retrieveByVector(vector, request);
     }
 
@@ -69,8 +68,7 @@ public class PgVectorRetrieverService implements VectorRetrieverService {
         if (collectionNames == null || collectionNames.isEmpty()) {
             return List.of();
         }
-        List<Float> embedding = embeddingService.embed(query);
-        float[] vector = normalize(toArray(embedding));
+        float[] vector = embedAndNormalize(query);
         // 全局检索：单条 SQL 在多库范围内做带总预算的 TopN 召回，替代逐库 fan-out
         return queryByCollections(vector, collectionNames, candidateBudget);
     }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
@@ -92,6 +92,7 @@ public interface VectorRetrieverService {
      * <p>
      * 注意：
      * - 调用方负责确保 vector 维度与向量库 schema 保持一致
+     * - 实现不得修改调用方传入的查询向量
      *
      * @param vector        查询向量（如 float[4096]）
      * @param retrieveParam 向量检索请求参数

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
@@ -100,6 +100,14 @@ public interface VectorRetrieverService {
     List<RetrievedChunk> retrieveByVector(float[] vector, RetrieveRequest retrieveParam);
 
     /**
+     * 根据自然语言 Query 生成并归一化查询向量。
+     *
+     * @param query 用户自然语言问题
+     * @return 最终用于向量数据库查询的向量
+     */
+    float[] embedAndNormalize(String query);
+
+    /**
      * 是否支持单次全局检索
      * <p>
      * - 返回 true 时，全局检索通道会调用 {@link #retrieveGlobal} 一次性跨库召回

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/VectorRetrieverService.java
@@ -100,7 +100,7 @@ public interface VectorRetrieverService {
     List<RetrievedChunk> retrieveByVector(float[] vector, RetrieveRequest retrieveParam);
 
     /**
-     * 根据自然语言 Query 生成并归一化查询向量。
+     * 根据自然语言 Query 生成并归一化查询向量
      *
      * @param query 用户自然语言问题
      * @return 最终用于向量数据库查询的向量

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/AbstractParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/AbstractParallelRetriever.java
@@ -18,6 +18,7 @@
 package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -44,9 +45,12 @@ import java.util.concurrent.Executor;
 @Slf4j
 public abstract class AbstractParallelRetriever<T> {
 
+    protected final VectorRetrieverService retrieverService;
     private final Executor executor;
 
-    protected AbstractParallelRetriever(Executor executor) {
+    protected AbstractParallelRetriever(VectorRetrieverService retrieverService,
+                                        Executor executor) {
+        this.retrieverService = retrieverService;
         this.executor = executor;
     }
 
@@ -61,6 +65,8 @@ public abstract class AbstractParallelRetriever<T> {
     public final List<RetrievedChunk> executeParallelRetrieval(String question,
                                                                List<T> targets,
                                                                int topK) {
+        float[] queryVector = retrieverService.embedAndNormalize(question);
+
         // 1. 创建 Future 列表
         record RetrievalFuture<T>(T target, CompletableFuture<List<RetrievedChunk>> future) {
         }
@@ -68,7 +74,7 @@ public abstract class AbstractParallelRetriever<T> {
         List<RetrievalFuture<T>> futures = targets.stream()
                 .map(target -> {
                     CompletableFuture<List<RetrievedChunk>> future = CompletableFuture.supplyAsync(
-                            () -> createRetrievalTask(question, target, topK),
+                            () -> createRetrievalTask(question, target, queryVector, topK),
                             executor
                     );
                     return new RetrievalFuture<>(target, future);
@@ -117,10 +123,11 @@ public abstract class AbstractParallelRetriever<T> {
      *
      * @param question 查询问题
      * @param target   检索目标
+     * @param queryVector 预计算后的查询向量
      * @param topK     TopK
      * @return 检索结果列表
      */
-    protected abstract List<RetrievedChunk> createRetrievalTask(String question, T target, int topK);
+    protected abstract List<RetrievedChunk> createRetrievalTask(String question, T target, float[] queryVector, int topK);
 
     /**
      * 获取目标标识（用于日志）

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetriever.java
@@ -20,7 +20,6 @@ package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
-import com.nageoffer.ai.ragent.rag.core.vector.strategy.AbstractParallelRetriever;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -33,17 +32,16 @@ import java.util.concurrent.Executor;
 @Slf4j
 public class CollectionParallelRetriever extends AbstractParallelRetriever<String> {
 
-    private final VectorRetrieverService retrieverService;
-
-    public CollectionParallelRetriever(VectorRetrieverService retrieverService, Executor executor) {
-        super(executor);
-        this.retrieverService = retrieverService;
+    public CollectionParallelRetriever(VectorRetrieverService retrieverService,
+                                       Executor executor) {
+        super(retrieverService, executor);
     }
 
     @Override
-    protected List<RetrievedChunk> createRetrievalTask(String question, String collectionName, int topK) {
+    protected List<RetrievedChunk> createRetrievalTask(String question, String collectionName, float[] queryVector, int topK) {
         try {
-            return retrieverService.retrieve(
+            return retrieverService.retrieveByVector(
+                    queryVector,
                     RetrieveRequest.builder()
                             .collectionName(collectionName)
                             .query(question)

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
@@ -34,15 +34,12 @@ import java.util.concurrent.Executor;
 @Slf4j
 public class IntentParallelRetriever extends AbstractParallelRetriever<IntentParallelRetriever.IntentTask> {
 
-    private final VectorRetrieverService retrieverService;
-
     public record IntentTask(NodeScore nodeScore, int intentTopK) {
     }
 
     public IntentParallelRetriever(VectorRetrieverService retrieverService,
                                    Executor executor) {
-        super(executor);
-        this.retrieverService = retrieverService;
+        super(retrieverService, executor);
     }
 
     /**
@@ -62,7 +59,7 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
     }
 
     @Override
-    protected List<RetrievedChunk> createRetrievalTask(String question, IntentTask task, int ignoredTopK) {
+    protected List<RetrievedChunk> createRetrievalTask(String question, IntentTask task, float[] queryVector, int ignoredTopK) {
         NodeScore nodeScore = task.nodeScore();
         IntentNode node = nodeScore.getNode();
         List<String> collectionNames = node.getEffectiveCollectionNames();
@@ -70,7 +67,8 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
             return List.of();
         }
         try {
-            return retrieverService.retrieve(
+            return retrieverService.retrieveByVector(
+                    queryVector,
                     RetrieveRequest.builder()
                             .collectionNames(collectionNames)
                             .query(question)

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetrieverTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/CollectionParallelRetrieverTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector.strategy;
+
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CollectionParallelRetrieverTest {
+
+    @Test
+    @DisplayName("fan-out全库检索时同一个子问题只生成一次Query向量")
+    void fanOutGlobalRetrievalEmbedSubQuestionOnce() {
+        VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        when(retrieverService.embedAndNormalize("报销流程")).thenReturn(new float[]{0.6F, 0.8F});
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class))).thenReturn(List.of());
+
+        CollectionParallelRetriever retriever = new CollectionParallelRetriever(retrieverService, Runnable::run);
+        retriever.executeParallelRetrieval("报销流程", List.of("kb-finance", "kb-policy"), 7);
+
+        verify(retrieverService, times(1)).embedAndNormalize("报销流程");
+        verify(retrieverService, times(2)).retrieveByVector(any(float[].class), any(RetrieveRequest.class));
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetrieverTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetrieverTest.java
@@ -17,10 +17,17 @@
 
 package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrievalBudget;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.KbCollectionProvider;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelResult;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchContext;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.VectorSearchChannel;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
+import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -41,7 +49,8 @@ class IntentParallelRetrieverTest {
     @DisplayName("单个意图关联多个Collection时只检索一次且共享节点TopK")
     void multipleCollectionsShareOneIntentTopK() {
         VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
-        when(retrieverService.retrieve(any(RetrieveRequest.class))).thenReturn(List.of());
+        when(retrieverService.embedAndNormalize("如何申请？")).thenReturn(new float[]{0.6F, 0.8F});
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class))).thenReturn(List.of());
 
         IntentNode node = IntentNode.builder()
                 .id("multi-kb-intent")
@@ -55,7 +64,7 @@ class IntentParallelRetrieverTest {
         retriever.retrieveByIntents("如何申请？", List.of(nodeScore), 20);
 
         ArgumentCaptor<RetrieveRequest> requestCaptor = ArgumentCaptor.forClass(RetrieveRequest.class);
-        verify(retrieverService, times(1)).retrieve(requestCaptor.capture());
+        verify(retrieverService, times(1)).retrieveByVector(any(float[].class), requestCaptor.capture());
         RetrieveRequest request = requestCaptor.getValue();
         assertEquals(List.of("kb-policy", "kb-process"), request.getEffectiveCollectionNames());
         assertEquals(6, request.getTopK(), "TopK 应是该意图跨所有 Collection 的总预算");
@@ -65,18 +74,34 @@ class IntentParallelRetrieverTest {
     @DisplayName("未绑定Collection的意图不会误查全库")
     void emptyCollectionsSkipDirectedRetrieval() {
         VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        KbCollectionProvider kbCollectionProvider = mock(KbCollectionProvider.class);
+        when(kbCollectionProvider.listActiveCollections()).thenReturn(List.of());
+
         IntentNode node = IntentNode.builder()
                 .id("empty-kb-intent")
                 .name("未配置知识库")
                 .build();
+        SearchContext context = SearchContext.builder()
+                .originalQuestion("如何申请？")
+                .intents(List.of(new SubQuestionIntent(
+                        "如何申请？",
+                        List.of(NodeScore.builder().node(node).score(0.95).build())
+                )))
+                .budget(RetrievalBudget.uniform(20))
+                .build();
 
-        IntentParallelRetriever retriever = new IntentParallelRetriever(retrieverService, Runnable::run);
-        retriever.retrieveByIntents(
-                "如何申请？",
-                List.of(NodeScore.builder().node(node).score(0.95).build()),
-                20
+        VectorSearchChannel channel = new VectorSearchChannel(
+                retrieverService,
+                new SearchChannelProperties(),
+                kbCollectionProvider,
+                Runnable::run
         );
 
+        SearchChannelResult result = channel.search(context);
+
+        assertTrue(result.getChunks().isEmpty());
+        assertEquals("global", result.getMetadata().get("scope"));
+        verify(kbCollectionProvider).listActiveCollections();
         verifyNoInteractions(retrieverService);
     }
 }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/ParallelQueryVectorReuseTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/ParallelQueryVectorReuseTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.vector.strategy;
+
+import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
+import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ParallelQueryVectorReuseTest {
+
+    @Test
+    @DisplayName("多个意图并行检索时复用同一个Query向量")
+    void multipleIntentsReuseOneQueryVector() {
+        VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        float[] normalizedVector = new float[]{0.6F, 0.8F};
+        when(retrieverService.embedAndNormalize("如何申请？")).thenReturn(normalizedVector);
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class))).thenReturn(List.of());
+
+        NodeScore first = NodeScore.builder()
+                .node(IntentNode.builder()
+                        .id("finance")
+                        .name("财务")
+                        .collectionNames(List.of("kb-finance"))
+                        .build())
+                .score(0.95)
+                .build();
+        NodeScore second = NodeScore.builder()
+                .node(IntentNode.builder()
+                        .id("policy")
+                        .name("制度")
+                        .collectionNames(List.of("kb-policy"))
+                        .build())
+                .score(0.9)
+                .build();
+
+        IntentParallelRetriever retriever = new IntentParallelRetriever(retrieverService, Runnable::run);
+        retriever.retrieveByIntents("如何申请？", List.of(first, second), 20);
+
+        ArgumentCaptor<float[]> vectorCaptor = ArgumentCaptor.forClass(float[].class);
+        verify(retrieverService, times(2)).retrieveByVector(vectorCaptor.capture(), any(RetrieveRequest.class));
+        assertSame(normalizedVector, vectorCaptor.getAllValues().get(0));
+        assertSame(normalizedVector, vectorCaptor.getAllValues().get(1));
+        verify(retrieverService, times(1)).embedAndNormalize("如何申请？");
+        verify(retrieverService, never()).retrieve(any(RetrieveRequest.class));
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/ParallelQueryVectorReuseTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/ParallelQueryVectorReuseTest.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -67,6 +68,8 @@ class ParallelQueryVectorReuseTest {
 
         ArgumentCaptor<float[]> vectorCaptor = ArgumentCaptor.forClass(float[].class);
         verify(retrieverService, times(2)).retrieveByVector(vectorCaptor.capture(), any(RetrieveRequest.class));
+        assertArrayEquals(normalizedVector, vectorCaptor.getAllValues().get(0));
+        assertArrayEquals(normalizedVector, vectorCaptor.getAllValues().get(1));
         assertSame(normalizedVector, vectorCaptor.getAllValues().get(0));
         assertSame(normalizedVector, vectorCaptor.getAllValues().get(1));
         verify(retrieverService, times(1)).embedAndNormalize("如何申请？");


### PR DESCRIPTION
# 修复并行检索中的 Query Embedding 重复计算

## 问题背景

当一个子问题需要并行检索多个意图或 Collection 时，`AbstractParallelRetriever` 会为每个检索目标创建异步任务。

改动前，每个任务都会调用 `VectorRetrieverService.retrieve(RetrieveRequest)`，并独立完成 Query Embedding、向量转换和归一化。单个子问题的并行检索耗时可以简化表示为：

$$
T_{\mathrm{before}} = \max(E_1 + R_1, \ldots, E_N + R_N)
$$

改动后，在创建并行任务前只生成一次 Query 向量：

$$
T_{\mathrm{after}} = E + \max(R_1, \ldots, R_N)
$$

其中：

- $E_i$ 表示第 $i$ 个任务重复执行 Query Embedding 及归一化的耗时。
- $E$ 表示改动后统一执行一次 Query Embedding 及归一化的耗时。
- $R_i$ 表示第 $i$ 个检索目标的向量数据库查询耗时。

## 改动前

<img width="1423" height="451" alt="image" src="https://github.com/user-attachments/assets/7991381c-7d6b-4072-97b2-1ae568f5206c" />

## 改动后

<img width="1510" height="403" alt="image" src="https://github.com/user-attachments/assets/08f68d54-dbc0-403a-a6cc-3774c0db2702" />

## 主要改动

### 1. 统一生成查询向量

在 `VectorRetrieverService` 中增加 `embedAndNormalize`，由 Milvus 和 PG 分别复用原有的 Embedding、向量转换及归一化逻辑。

Milvus 和 PG 的以下入口统一调用 `embedAndNormalize`：

- `retrieve`
- `retrieveGlobal`

避免不同检索入口分别实现相同的向量准备逻辑。

### 2. 在并行任务创建前生成向量

`AbstractParallelRetriever.executeParallelRetrieval` 在创建异步任务前调用一次 `embedAndNormalize`，然后将生成的 `queryVector` 传给所有并行任务。

同一次并行检索中的所有任务共享该 Query 向量，不再分别调用 Embedding 服务。

### 3. 直接使用预计算向量检索

`IntentParallelRetriever` 和 `CollectionParallelRetriever` 使用预计算的 `queryVector`，直接调用：

```java
retrieveByVector(queryVector, request)
```

不再通过 `retrieve(RetrieveRequest)` 重复生成 Query Embedding。

### 4. 明确共享向量的只读契约

在 `retrieveByVector` 的接口 Javadoc 中明确：

> 实现不得修改调用方传入的查询向量。

当前 Milvus 和 PG 实现均只读取传入向量，因此可以在线程间安全复用同一个 `float[]`。

## 改动边界

本次仅去除单次并行检索内，一个子问题因命中多个意图或 Collection 而产生的重复 Embedding、向量转换和归一化。

不涉及请求级多子问题批处理，也不实现 `(query, embeddingModel)` 级别的分组和去重。

## 单元测试

新增及更新以下测试场景：

- fan-out 全库检索时，同一个子问题只生成一次 Query 向量。
- 多个意图并行检索时，只生成一次 Query 向量，并由所有任务复用。
- 验证所有并行任务收到的向量值与归一化结果一致。
- 验证所有并行任务复用同一个数组引用，没有额外复制。
- 单个意图关联多个 Collection 时，仍只执行一次向量检索，并保留该意图的节点级 TopK。
- 从 `VectorSearchChannel.search` 真实调用入口验证：未绑定 Collection 的意图会在构建 KB 意图列表时被提前过滤；当不存在其他有效检索目标时，不会产生无效的 Query Embedding 请求。

定向测试结果：

```text
Tests run: 5
Failures: 0
Errors: 0
Skipped: 0
```

## 性能测试

### 测试环境

- 评测框架：`ragenteval`
- Embedding 模型：硅基流动 `Qwen3-Embedding-8B`
- 并发数：3
- 知识库数量：4
- 对照方式：Baseline 与 Optimized 交替运行三轮，结果取平均值。

### 全部请求

| 指标 | 优化前 | 优化后 | 变化 |
| --- | ---: | ---: | ---: |
| TTFT P50 | 5053 ms | 4448.5 ms | **-12.0%** |
| TTFT 平均值 | 6452 ms | 6219.5 ms | **-3.6%** |

### 实际命中多个 KB 的请求

| 指标 | 优化前 | 优化后 | 变化 |
| --- | ---: | ---: | ---: |
| TTFT P50 | 8781 ms | 7378 ms | **-16.0%** |
| TTFT 平均值 | 9551.4 ms | 7928.6 ms | **-17.0%** |

## 关联 Issue

Refs #58