### PR TITLE
fix(chat): 首包探测中断时由持有者释放熔断半开探测名额

### DIFF
--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMServiceHalfOpenRecoveryTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMServiceHalfOpenRecoveryTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.chat;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.framework.exception.RemoteException;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.model.ModelHealthStore;
+import com.nageoffer.ai.ragent.infra.model.ModelRoutingExecutor;
+import com.nageoffer.ai.ragent.infra.model.ModelSelector;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoutingLLMServiceHalfOpenRecoveryTest {
+
+    private static final String MODEL_ID = "mock-model";
+
+    private ModelHealthStore healthStore;
+    private RoutingLLMService service;
+    private StreamCallback callback;
+    private ChatClient client;
+    private LlmFirstPacketProbe probe;
+
+    private void initService(int failureThreshold, long openDurationMs) throws InterruptedException {
+        AIModelProperties properties = new AIModelProperties();
+        properties.getSelection().setFailureThreshold(failureThreshold);
+        properties.getSelection().setOpenDurationMs(openDurationMs);
+        healthStore = new ModelHealthStore(properties);
+
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId(MODEL_ID);
+        candidate.setProvider("mock");
+        ModelTarget target = new ModelTarget(MODEL_ID, candidate, new AIModelProperties.ProviderConfig(), 1000L);
+
+        ModelSelector selector = mock(ModelSelector.class);
+        when(selector.selectChatCandidates(anyBoolean())).thenReturn(List.of(target));
+
+        client = mock(ChatClient.class);
+        when(client.provider()).thenReturn("mock");
+        when(client.streamChat(any(), any(), any())).thenReturn(() -> {
+        });
+
+        probe = mock(LlmFirstPacketProbe.class);
+        when(probe.awaitFirstPacket(any(), anyLong(), any(TimeUnit.class)))
+                .thenThrow(new InterruptedException("simulated interrupt"));
+
+        callback = mock(StreamCallback.class);
+        service = new RoutingLLMService(selector, healthStore,
+                mock(ModelRoutingExecutor.class), probe, List.of(client));
+    }
+
+    private void streamChatExpectingInterrupt() {
+        assertThrows(RemoteException.class, () -> service.streamChat(new ChatRequest(), callback));
+    }
+
+    @AfterEach
+    void clearInterruptFlag() {
+        Thread.interrupted();
+    }
+
+    @Test
+    void interruptedHalfOpenProbeReleasesPermit() throws InterruptedException {
+        initService(1, 0L);
+        healthStore.markFailure(MODEL_ID);
+        streamChatExpectingInterrupt();
+        assertNotNull(healthStore.allowCall(MODEL_ID));
+    }
+
+    @Test
+    void interruptedHalfOpenProbeKeepsModelAvailable() throws InterruptedException {
+        initService(1, 0L);
+        healthStore.markFailure(MODEL_ID);
+
+        streamChatExpectingInterrupt();
+        assertFalse(healthStore.isUnavailable(MODEL_ID));
+    }
+
+    @Test
+    void closedStateInterruptDoesNotCountAsFailure() throws InterruptedException {
+        initService(2, 60_000L);
+
+        streamChatExpectingInterrupt();
+        healthStore.markFailure(MODEL_ID);
+        assertNotNull(healthStore.allowCall(MODEL_ID));
+    }
+
+    @Test
+    void closedStateInterruptDoesNotOpenCircuit() throws InterruptedException {
+        initService(1, 60_000L);
+
+        streamChatExpectingInterrupt();
+
+        assertNotNull(healthStore.allowCall(MODEL_ID));
+        assertFalse(healthStore.isUnavailable(MODEL_ID));
+    }
+
+    @Test
+    void staleClosedCallCannotReleaseAnotherProbePermit() throws InterruptedException {
+        initService(1, 0L);
+        when(probe.awaitFirstPacket(any(), anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
+            healthStore.markFailure(MODEL_ID);
+            healthStore.allowCall(MODEL_ID);
+            throw new InterruptedException("stale closed caller interrupted");
+        });
+        streamChatExpectingInterrupt();
+
+        assertNull(healthStore.allowCall(MODEL_ID));
+        assertTrue(healthStore.isUnavailable(MODEL_ID));
+    }
+
+    @Test
+    void staleHalfOpenPermitCannotReleaseCurrentPermit() throws InterruptedException {
+        initService(1, 0L);
+        healthStore.markFailure(MODEL_ID);
+        ModelHealthStore.CallPermit permit1 = healthStore.allowCall(MODEL_ID);
+        assertNotNull(permit1);
+        assertTrue(permit1.halfOpenToken() > 0);
+        healthStore.markFailure(MODEL_ID);
+        ModelHealthStore.CallPermit permit2 = healthStore.allowCall(MODEL_ID);
+        assertNotNull(permit2);
+        assertTrue(permit2.halfOpenToken() > 0);
+        healthStore.releaseHalfOpenPermit(permit1);
+
+        assertNull(healthStore.allowCall(MODEL_ID));
+        assertTrue(healthStore.isUnavailable(MODEL_ID));
+    }
+
+    @Test
+    void interruptCancelsProbeBeforeReleasingPermit() throws InterruptedException {
+        initService(1, 0L);
+        healthStore.markFailure(MODEL_ID);
+        AtomicBoolean heldAtCancelTime = new AtomicBoolean(false);
+        when(client.streamChat(any(), any(), any())).thenReturn(
+                () -> heldAtCancelTime.set(healthStore.isUnavailable(MODEL_ID)));
+
+        streamChatExpectingInterrupt();
+
+        assertTrue(heldAtCancelTime.get());
+        assertFalse(healthStore.isUnavailable(MODEL_ID));
+    }
+
+    @Test
+    void cancelFailureStillReleasesPermit() throws InterruptedException {
+        initService(1, 0L);
+        healthStore.markFailure(MODEL_ID);
+        when(client.streamChat(any(), any(), any())).thenReturn(() -> {
+            throw new IllegalStateException("cancel failed");
+        });
+
+        assertThrows(RuntimeException.class, () -> service.streamChat(new ChatRequest(), callback));
+
+        assertFalse(healthStore.isUnavailable(MODEL_ID));
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMService.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/RoutingLLMService.java
@@ -126,7 +126,8 @@ public class RoutingLLMService implements LLMService {
             if (client == null) {
                 continue;
             }
-            if (!healthStore.allowCall(target.id())) {
+            ModelHealthStore.CallPermit permit = healthStore.allowCall(target.id());
+            if (permit == null) {
                 continue;
             }
 
@@ -151,7 +152,7 @@ public class RoutingLLMService implements LLMService {
             }
 
             long firstPacketBudgetMs = target.timeoutMs();
-            ProbeStreamBridge.ProbeResult result = awaitFirstPacket(bridge, handle, callback, firstPacketBudgetMs);
+            ProbeStreamBridge.ProbeResult result = awaitFirstPacket(bridge, handle, callback, firstPacketBudgetMs, permit);
 
             if (result.isSuccess()) {
                 healthStore.markSuccess(target.id());
@@ -181,12 +182,17 @@ public class RoutingLLMService implements LLMService {
     private ProbeStreamBridge.ProbeResult awaitFirstPacket(ProbeStreamBridge bridge,
                                                            StreamCancellationHandle handle,
                                                            StreamCallback callback,
-                                                           long firstPacketBudgetMs) {
+                                                           long firstPacketBudgetMs,
+                                                           ModelHealthStore.CallPermit permit) {
         try {
             return firstPacketProbe.awaitFirstPacket(bridge, firstPacketBudgetMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            handle.cancel();
+            try {
+                handle.cancel();
+            } finally {
+                healthStore.releaseHalfOpenPermit(permit);
+            }
             RemoteException interruptedException = new RemoteException(STREAM_INTERRUPTED_MESSAGE, e, BaseErrorCode.REMOTE_ERROR);
             callback.onError(interruptedException);
             throw interruptedException;

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelHealthStore.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelHealthStore.java
@@ -23,7 +23,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * 模型健康状态存储器
@@ -37,6 +38,14 @@ public class ModelHealthStore {
 
     private final Map<String, ModelHealth> healthById = new ConcurrentHashMap<>();
 
+    private final AtomicLong probeTokenSeq = new AtomicLong();
+
+    /**
+     * 模型调用许可，halfOpenToken 为 0 时不持有半开探测名额
+     */
+    public record CallPermit(String modelId, long halfOpenToken) {
+    }
+
     public boolean isUnavailable(String id) {
         ModelHealth health = healthById.get(id);
         if (health == null) {
@@ -48,13 +57,15 @@ public class ModelHealthStore {
         return health.state == State.HALF_OPEN && health.halfOpenInFlight;
     }
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public boolean allowCall(String id) {
+    /**
+     * 返回 null 表示拒绝调用
+     */
+    public CallPermit allowCall(String id) {
         if (id == null) {
-            return false;
+            return null;
         }
         long now = System.currentTimeMillis();
-        AtomicBoolean allowed = new AtomicBoolean(false);
+        AtomicReference<CallPermit> granted = new AtomicReference<>();
         healthById.compute(id, (k, v) -> {
             if (v == null) {
                 v = new ModelHealth();
@@ -65,7 +76,8 @@ public class ModelHealthStore {
                 }
                 v.state = State.HALF_OPEN;
                 v.halfOpenInFlight = true;
-                allowed.set(true);
+                v.halfOpenToken = probeTokenSeq.incrementAndGet();
+                granted.set(new CallPermit(id, v.halfOpenToken));
                 return v;
             }
             if (v.state == State.HALF_OPEN) {
@@ -73,13 +85,14 @@ public class ModelHealthStore {
                     return v;
                 }
                 v.halfOpenInFlight = true;
-                allowed.set(true);
+                v.halfOpenToken = probeTokenSeq.incrementAndGet();
+                granted.set(new CallPermit(id, v.halfOpenToken));
                 return v;
             }
-            allowed.set(true);
+            granted.set(new CallPermit(id, 0L));
             return v;
         });
-        return allowed.get();
+        return granted.get();
     }
 
     public void markSuccess(String id) {
@@ -124,16 +137,33 @@ public class ModelHealthStore {
         });
     }
 
+    /**
+     * 仅释放当前凭证持有的半开探测名额
+     */
+    public void releaseHalfOpenPermit(CallPermit permit) {
+        if (permit == null || permit.halfOpenToken() <= 0L) {
+            return;
+        }
+        healthById.computeIfPresent(permit.modelId(), (k, v) -> {
+            if (v.state == State.HALF_OPEN && v.halfOpenInFlight && v.halfOpenToken == permit.halfOpenToken()) {
+                v.halfOpenInFlight = false;
+            }
+            return v;
+        });
+    }
+
     private static class ModelHealth {
         private int consecutiveFailures;
         private long openUntil;
         private boolean halfOpenInFlight;
+        private long halfOpenToken;
         private State state;
 
         private ModelHealth() {
             this.consecutiveFailures = 0;
             this.openUntil = 0L;
             this.halfOpenInFlight = false;
+            this.halfOpenToken = 0L;
             this.state = State.CLOSED;
         }
     }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelRoutingExecutor.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelRoutingExecutor.java
@@ -55,7 +55,7 @@ public class ModelRoutingExecutor {
                 log.warn("{} provider client missing: provider={}, modelId={}", label, target.candidate().getProvider(), target.id());
                 continue;
             }
-            if (!healthStore.allowCall(target.id())) {
+            if (healthStore.allowCall(target.id()) == null) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #74

## 问题

流式调用在等待首包时被中断，如果该调用持有 HALF_OPEN 的唯一探测名额，名额不会归还。后续调用无法再选择该模型，只能通过重启恢复。

## 修改

- `allowCall` 返回 `CallPermit`，记录半开 token
- `releaseHalfOpenPermit` 只释放 token 匹配的当前名额
- 中断时先取消探测，并在 `finally` 中释放名额

CLOSED 调用不持有半开名额，释放时不会修改失败计数。正常成功、失败和超时逻辑不变。

## 测试

`RoutingLLMServiceHalfOpenRecoveryTest` 覆盖中断释放、CLOSED 状态、过期调用、旧 token、取消顺序和取消异常。

```text
RoutingLLMServiceHalfOpenRecoveryTest: 8/8 通过
ModelSelectorTest: 9/9 通过
Spotless: 通过
git diff --check: 通过
```

本次所有权校验只用于中断释放。`markSuccess` 和 `markFailure` 的跨周期所有权不在本次改动范围内。
