### PR TITLE
fix(rag): 修正查询改写历史窗口计算

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
@@ -136,10 +136,12 @@ public class MultiQuestionRewriteService implements QueryRewriteService {
         // 只保留最近 1-2 轮的 User 和 Assistant 消息
         // 过滤掉 System 摘要，避免 Token 浪费
         if (CollUtil.isNotEmpty(history)) {
-            List<ChatMessage> recentHistory = history.stream()
+            List<ChatMessage> dialogueHistory = history.stream()
                     .filter(msg -> msg.getRole() == ChatMessage.Role.USER
                             || msg.getRole() == ChatMessage.Role.ASSISTANT)
-                    .skip(Math.max(0, history.size() - 4))  // 最多保留最近 4 条消息（2 轮对话）
+                    .toList();
+            List<ChatMessage> recentHistory = dialogueHistory.stream()
+                    .skip(Math.max(0, dialogueHistory.size() - 4))  // 最多保留最近 4 条消息（2 轮对话）
                     .toList();
             messages.addAll(recentHistory);
         }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteServiceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.rewrite;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatMessage;
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.infra.enums.Tier;
+import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MultiQuestionRewriteServiceTest {
+
+    @Mock
+    private LLMService llmService;
+
+    @Mock
+    private RAGConfigProperties ragConfigProperties;
+
+    @Mock
+    private QueryTermMappingService queryTermMappingService;
+
+    @Mock
+    private PromptTemplateLoader promptTemplateLoader;
+
+    private MultiQuestionRewriteService rewriteService;
+
+    @BeforeEach
+    void setUp() {
+        rewriteService = new MultiQuestionRewriteService(
+                llmService,
+                ragConfigProperties,
+                queryTermMappingService,
+                promptTemplateLoader
+        );
+    }
+
+    @Test
+    void keepsLastFourDialogueMessagesWhenSummaryIsPresent() {
+        when(ragConfigProperties.getQueryRewriteEnabled()).thenReturn(true);
+        when(queryTermMappingService.normalize("继续说说它")).thenReturn("继续说说它");
+        when(promptTemplateLoader.load(anyString())).thenReturn("rewrite prompt");
+        when(llmService.chat(any(ChatRequest.class), eq(Tier.FAST)))
+                .thenReturn("{\"rewrite\":\"继续说明 RAG\",\"sub_questions\":[\"继续说明 RAG\"]}");
+
+        List<ChatMessage> history = List.of(
+                ChatMessage.system("conversation summary"),
+                ChatMessage.user("user-1"),
+                ChatMessage.assistant("assistant-1"),
+                ChatMessage.user("user-2"),
+                ChatMessage.assistant("assistant-2"),
+                ChatMessage.user("user-3"),
+                ChatMessage.assistant("assistant-3")
+        );
+
+        rewriteService.rewriteWithSplit("继续说说它", history);
+
+        ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+        verify(llmService).chat(requestCaptor.capture(), eq(Tier.FAST));
+        List<ChatMessage> messages = requestCaptor.getValue().getMessages();
+
+        assertEquals(
+                List.of("rewrite prompt", "user-2", "assistant-2", "user-3", "assistant-3", "继续说说它"),
+                messages.stream().map(ChatMessage::getContent).toList()
+        );
+        assertEquals(
+                List.of(
+                        ChatMessage.Role.SYSTEM,
+                        ChatMessage.Role.USER,
+                        ChatMessage.Role.ASSISTANT,
+                        ChatMessage.Role.USER,
+                        ChatMessage.Role.ASSISTANT,
+                        ChatMessage.Role.USER
+                ),
+                messages.stream().map(ChatMessage::getRole).toList()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- 在过滤 `SYSTEM` 摘要后，再根据过滤后的对话消息数量计算查询改写历史窗口
- 确保改写模型始终获得最近 4 条 `USER` / `ASSISTANT` 消息
- 增加包含会话摘要的回归测试，覆盖消息数量、顺序和角色

## Why

会话摘要会被放在历史列表首位。旧实现虽然先过滤摘要，却仍使用原列表长度计算 `skip`，导致存在摘要时多丢弃一条近期对话，可能影响多轮问题的指代消解和后续检索召回。

## Verification

- `git diff --cached --check`：通过
- `mvn -s .codex-maven-settings.xml -pl bootstrap -am -Dtest=MultiQuestionRewriteServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`：本机首次解析 Spring Boot 3.5.7 / Tika 3.2.3 依赖时 10 分钟超时，尚未进入测试报告阶段

Closes #76
