### PR TITLE
fix(trace): 用户取消后将 trace run 收尾为 CANCELLED

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/admin/service/impl/DashboardServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/admin/service/impl/DashboardServiceImpl.java
@@ -58,6 +58,7 @@ public class DashboardServiceImpl implements DashboardService {
 
     private static final String STATUS_SUCCESS = "SUCCESS";
     private static final String STATUS_ERROR = "ERROR";
+    private static final String STATUS_CANCELLED = "CANCELLED";
     private static final String ROLE_ASSISTANT = "assistant";
     private static final String NO_DOC_REPLY = "未检索到与问题相关的文档内容。";
     private static final String GRANULARITY_DAY = "day";
@@ -114,7 +115,9 @@ public class DashboardServiceImpl implements DashboardService {
 
         long success = countTraceRuns(range.start, range.end, STATUS_SUCCESS);
         long error = countTraceRuns(range.start, range.end, STATUS_ERROR);
-        long total = success + error;
+        // 被用户取消的会话同样是一次真实请求，必须计入分母，否则「用户等不及点了停止」这一负面信号会被系统性剔除
+        long cancelled = countTraceRuns(range.start, range.end, STATUS_CANCELLED);
+        long total = success + error + cancelled;
         long assistantCount = countAssistantMessages(range.start, range.end);
         long noDocCount = countNoDocMessages(range.start, range.end);
         long slowCount = durations.stream().filter(duration -> duration > SLOW_LATENCY_THRESHOLD_MS).count();

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/RagTraceRecordService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/RagTraceRecordService.java
@@ -31,6 +31,19 @@ public interface RagTraceRecordService {
 
     void finishRun(String traceId, String status, String errorMessage, Date endTime, long durationMs);
 
+    /**
+     * 将指定任务仍处于 RUNNING 的 trace run 收尾为 CANCELLED
+     * <p>
+     * 取消信号在 provider client 层被拦截（{@code ForwardingStreamCallback} 对外部取消不透传 delegate，
+     * 否则流式 failover 切换候选时会终止用户 SSE），run 级终态无法由回调链驱动，只能按 taskId 单独上报
+     * </p>
+     *
+     * @param taskId  流式任务 ID
+     * @param endTime 取消发生的时间
+     * @return 是否确实有一行由 RUNNING 翻转为 CANCELLED
+     */
+    boolean cancelRunByTaskId(String taskId, Date endTime);
+
     void startNode(RagTraceNodeDO node);
 
     void finishNode(String traceId, String nodeId, String status, String errorMessage, Date endTime, long durationMs);

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamTaskManager.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamTaskManager.java
@@ -24,6 +24,7 @@ import com.nageoffer.ai.ragent.rag.enums.SSEEventType;
 import com.nageoffer.ai.ragent.rag.dto.CompletionPayload;
 import com.nageoffer.ai.ragent.framework.web.SseEmitterSender;
 import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.rag.service.RagTraceRecordService;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.SneakyThrows;
@@ -34,6 +35,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -51,10 +53,12 @@ public class StreamTaskManager {
             .build();
 
     private final RedissonClient redissonClient;
+    private final RagTraceRecordService traceRecordService;
     private int listenerId = -1;
 
-    public StreamTaskManager(RedissonClient redissonClient) {
+    public StreamTaskManager(RedissonClient redissonClient, RagTraceRecordService traceRecordService) {
         this.redissonClient = redissonClient;
+        this.traceRecordService = traceRecordService;
     }
 
     @PostConstruct
@@ -148,6 +152,26 @@ public class StreamTaskManager {
             CompletionPayload payload = taskInfo.onCancelSupplier.get();
             sendCancelAndDone(taskInfo.sender, payload);
             taskInfo.sender.complete();
+        }
+
+        reportTraceRunCancelled(taskId);
+    }
+
+    /**
+     * 上报 run 级取消终态
+     * <p>
+     * 取消信号在 provider client 层就被 {@code ForwardingStreamCallback} 拦截了（对外部取消不透传 delegate，
+     * 否则流式 failover 切换候选时会终止用户 SSE），run 级终态无法由回调链驱动。
+     * 而 {@code cancelLocal} 的 CAS 成功分支是全链路唯一能确定「这是用户主动取消」而非「failover 内部取消」的位置，
+     * 因此在这里上报
+     * </p>
+     */
+    private void reportTraceRunCancelled(String taskId) {
+        try {
+            traceRecordService.cancelRunByTaskId(taskId, new Date());
+        } catch (Exception e) {
+            // trace 是旁路观测，失败不能影响取消本身
+            log.warn("上报 trace run 取消状态失败，任务ID：{}", taskId, e);
         }
     }
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceRecordServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceRecordServiceImpl.java
@@ -35,6 +35,9 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class RagTraceRecordServiceImpl implements RagTraceRecordService {
 
+    private static final String STATUS_RUNNING = "RUNNING";
+    private static final String STATUS_CANCELLED = "CANCELLED";
+
     private final RagTraceRunMapper runMapper;
     private final RagTraceNodeMapper nodeMapper;
 
@@ -53,6 +56,28 @@ public class RagTraceRecordServiceImpl implements RagTraceRecordService {
                 .build();
         runMapper.update(update, Wrappers.lambdaUpdate(RagTraceRunDO.class)
                 .eq(RagTraceRunDO::getTraceId, traceId));
+    }
+
+    @Override
+    public boolean cancelRunByTaskId(String taskId, Date endTime) {
+        RagTraceRunDO running = runMapper.selectOne(Wrappers.lambdaQuery(RagTraceRunDO.class)
+                .eq(RagTraceRunDO::getTaskId, taskId)
+                .eq(RagTraceRunDO::getStatus, STATUS_RUNNING)
+                .orderByDesc(RagTraceRunDO::getStartTime)
+                .last("LIMIT 1"));
+        if (running == null) {
+            return false;
+        }
+
+        RagTraceRunDO update = RagTraceRunDO.builder()
+                .status(STATUS_CANCELLED)
+                .endTime(endTime)
+                .durationMs(Math.max(0, endTime.getTime() - running.getStartTime().getTime()))
+                .build();
+        // 带 status 的条件更新：与正常终态（onComplete / onError）竞争时只有一方能生效
+        return runMapper.update(update, Wrappers.lambdaUpdate(RagTraceRunDO.class)
+                .eq(RagTraceRunDO::getTraceId, running.getTraceId())
+                .eq(RagTraceRunDO::getStatus, STATUS_RUNNING)) > 0;
     }
 
     @Override

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/admin/service/impl/DashboardPerformanceCancelledTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/admin/service/impl/DashboardPerformanceCancelledTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.admin.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.nageoffer.ai.ragent.admin.controller.vo.DashboardPerformanceVO;
+import com.nageoffer.ai.ragent.rag.dao.entity.RagTraceRunDO;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationMapper;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationMessageMapper;
+import com.nageoffer.ai.ragent.rag.dao.mapper.RagTraceRunMapper;
+import com.nageoffer.ai.ragent.user.dao.mapper.UserMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 被用户取消的会话必须计入成功率分母
+ * <p>
+ * 否则「用户等不及点了停止」这一最该被捕捉的负面信号会被系统性剔除，看板呈现幸存者偏差
+ * </p>
+ */
+class DashboardPerformanceCancelledTest {
+
+    private RagTraceRunMapper traceRunMapper;
+    private ConversationMessageMapper messageMapper;
+    private DashboardServiceImpl dashboardService;
+
+    @BeforeEach
+    void setUp() {
+        traceRunMapper = mock(RagTraceRunMapper.class);
+        messageMapper = mock(ConversationMessageMapper.class);
+        dashboardService = new DashboardServiceImpl(
+                mock(UserMapper.class),
+                mock(ConversationMapper.class),
+                messageMapper,
+                traceRunMapper);
+    }
+
+    @Test
+    void countsCancelledRunsInSuccessRateDenominator() {
+        stubTraceRunCount("SUCCESS", 6L);
+        stubTraceRunCount("ERROR", 2L);
+        stubTraceRunCount("CANCELLED", 2L);
+        when(traceRunMapper.selectObjs(any())).thenReturn(Collections.emptyList());
+        when(messageMapper.selectCount(any())).thenReturn(0L);
+
+        DashboardPerformanceVO performance = dashboardService.loadPerformance("24h");
+
+        // 分母 = 6 + 2 + 2 = 10，而非只算成功与失败的 8
+        assertEquals(60.0, performance.getSuccessRate());
+        assertEquals(20.0, performance.getErrorRate());
+    }
+
+    private void stubTraceRunCount(String status, long count) {
+        when(traceRunMapper.selectCount(argThat(wrapperMatching(status)))).thenReturn(count);
+    }
+
+    private static ArgumentMatcher<Wrapper<RagTraceRunDO>> wrapperMatching(String status) {
+        return wrapper -> {
+            if (!(wrapper instanceof QueryWrapper<?> queryWrapper)) {
+                return false;
+            }
+            // MyBatis-Plus 的条件值是惰性写入 paramNameValuePairs 的，先触发 SQL 片段生成
+            queryWrapper.getTargetSql();
+            return queryWrapper.getParamNameValuePairs().containsValue(status);
+        };
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/StreamTaskManagerCancelTraceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/StreamTaskManagerCancelTraceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.rag.service.RagTraceRecordService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.MessageListener;
+
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 用户主动取消时，对应的 trace run 必须收尾为 CANCELLED
+ * <p>
+ * 取消信号在 provider client 层被 {@code ForwardingStreamCallback.finishExternally} 刻意拦截（不透传 delegate，
+ * 否则流式 failover 切换候选时会终止用户 SSE），因此 run 级终态只能由本类上报 ——
+ * 全链路只有这里能区分「用户主动取消」与「failover 内部取消」
+ * </p>
+ */
+class StreamTaskManagerCancelTraceTest {
+
+    private static final String TASK_ID = "task-1";
+
+    private RedissonClient redissonClient;
+    private RTopic topic;
+    private RagTraceRecordService traceRecordService;
+    private StreamTaskManager taskManager;
+    private StreamCancellationHandle handle;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redissonClient = mock(RedissonClient.class);
+        topic = mock(RTopic.class);
+        traceRecordService = mock(RagTraceRecordService.class);
+        handle = mock(StreamCancellationHandle.class);
+        when(redissonClient.getTopic(any(String.class))).thenReturn(topic);
+
+        taskManager = new StreamTaskManager(redissonClient, traceRecordService);
+    }
+
+    @Test
+    void reportsCancelledTraceRunOnUserCancel() {
+        MessageListener<String> listener = subscribeAndCaptureListener();
+        taskManager.bindHandle(TASK_ID, handle);
+
+        listener.onMessage("channel", TASK_ID);
+
+        verify(handle).cancel();
+        verify(traceRecordService).cancelRunByTaskId(eq(TASK_ID), any(Date.class));
+    }
+
+    @Test
+    void reportsCancelledTraceRunOnlyOnce() {
+        MessageListener<String> listener = subscribeAndCaptureListener();
+        taskManager.bindHandle(TASK_ID, handle);
+
+        listener.onMessage("channel", TASK_ID);
+        listener.onMessage("channel", TASK_ID);
+
+        verify(traceRecordService, times(1)).cancelRunByTaskId(eq(TASK_ID), any(Date.class));
+    }
+
+    @Test
+    void skipsTraceReportForUnknownTask() {
+        MessageListener<String> listener = subscribeAndCaptureListener();
+
+        listener.onMessage("channel", "not-registered");
+
+        verify(traceRecordService, never()).cancelRunByTaskId(any(), any());
+    }
+
+    @Test
+    void stillCancelsStreamWhenTraceReportFails() {
+        MessageListener<String> listener = subscribeAndCaptureListener();
+        taskManager.bindHandle(TASK_ID, handle);
+        doThrow(new RuntimeException("trace 库不可用"))
+                .when(traceRecordService).cancelRunByTaskId(any(), any());
+
+        listener.onMessage("channel", TASK_ID);
+
+        verify(handle).cancel();
+    }
+
+    @SuppressWarnings("unchecked")
+    private MessageListener<String> subscribeAndCaptureListener() {
+        taskManager.subscribe();
+        ArgumentCaptor<MessageListener<String>> captor = ArgumentCaptor.forClass(MessageListener.class);
+        verify(topic).addListener(eq(String.class), captor.capture());
+        return captor.getValue();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceRecordServiceImplTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/impl/RagTraceRecordServiceImplTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.impl;
+
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.nageoffer.ai.ragent.rag.dao.entity.RagTraceRunDO;
+import com.nageoffer.ai.ragent.rag.dao.mapper.RagTraceNodeMapper;
+import com.nageoffer.ai.ragent.rag.dao.mapper.RagTraceRunMapper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code cancelRunByTaskId} 必须是一次条件更新：只翻转仍处于 RUNNING 的行，
+ * 以便与正常终态（SUCCESS / ERROR）竞争时最多一方生效
+ */
+class RagTraceRecordServiceImplTest {
+
+    private static final String TASK_ID = "task-1";
+    private static final String TRACE_ID = "trace-1";
+
+    private RagTraceRunMapper runMapper;
+    private RagTraceRecordServiceImpl service;
+
+    @BeforeAll
+    static void initTableMetadata() {
+        // LambdaWrapper 生成 SQL 依赖 MyBatis-Plus 的表元数据缓存，纯单测环境需要手动初始化
+        TableInfoHelper.initTableInfo(
+                new MapperBuilderAssistant(new MybatisConfiguration(), ""),
+                RagTraceRunDO.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        runMapper = mock(RagTraceRunMapper.class);
+        service = new RagTraceRecordServiceImpl(runMapper, mock(RagTraceNodeMapper.class));
+    }
+
+    @Test
+    void cancelsRunningRunAndComputesDurationFromStartTime() {
+        Date startTime = new Date(1_000_000L);
+        Date endTime = new Date(1_002_500L);
+        when(runMapper.selectOne(any())).thenReturn(RagTraceRunDO.builder()
+                .traceId(TRACE_ID)
+                .taskId(TASK_ID)
+                .status("RUNNING")
+                .startTime(startTime)
+                .build());
+        when(runMapper.update(any(), any())).thenReturn(1);
+
+        assertTrue(service.cancelRunByTaskId(TASK_ID, endTime));
+
+        ArgumentCaptor<RagTraceRunDO> captor = ArgumentCaptor.forClass(RagTraceRunDO.class);
+        verify(runMapper).update(captor.capture(), any());
+        RagTraceRunDO update = captor.getValue();
+        assertEquals("CANCELLED", update.getStatus());
+        assertEquals(endTime, update.getEndTime());
+        assertEquals(2500L, update.getDurationMs());
+    }
+
+    @Test
+    void constrainsUpdateToRowsStillRunning() {
+        when(runMapper.selectOne(any())).thenReturn(RagTraceRunDO.builder()
+                .traceId(TRACE_ID)
+                .status("RUNNING")
+                .startTime(new Date())
+                .build());
+        when(runMapper.update(any(), any())).thenReturn(1);
+
+        service.cancelRunByTaskId(TASK_ID, new Date());
+
+        ArgumentCaptor<Wrapper<RagTraceRunDO>> captor = ArgumentCaptor.forClass(Wrapper.class);
+        verify(runMapper).update(any(), captor.capture());
+        assertTrue(captor.getValue().getTargetSql().contains("status"),
+                "更新条件必须带 status，否则会覆盖已收尾的终态");
+    }
+
+    @Test
+    void skipsUpdateWhenTaskHasNoRunningRun() {
+        when(runMapper.selectOne(any())).thenReturn(null);
+
+        assertFalse(service.cancelRunByTaskId(TASK_ID, new Date()));
+
+        verify(runMapper, never()).update(any(), any());
+    }
+
+    @Test
+    void reportsNotCancelledWhenNormalFinishWonTheRace() {
+        when(runMapper.selectOne(any())).thenReturn(RagTraceRunDO.builder()
+                .traceId(TRACE_ID)
+                .status("RUNNING")
+                .startTime(new Date())
+                .build());
+        when(runMapper.update(any(), any())).thenReturn(0);
+
+        assertFalse(service.cancelRunByTaskId(TASK_ID, new Date()));
+    }
+}


### PR DESCRIPTION
## 关联 Issue

Closes #79

## 改动内容

修复「用户点停止生成后 `t_rag_trace_run` 永远停在 RUNNING」的问题，并让 Dashboard 成功率分母纳入 `CANCELLED`。

| 文件 | 改动 |
|:--|:--|
| `RagTraceRecordService(+Impl)` | 新增 `cancelRunByTaskId(taskId, endTime)` |
| `StreamTaskManager` | `cancelLocal` 的 CAS 成功分支上报取消终态 |
| `DashboardServiceImpl` | 成功率 / 错误率分母纳入 `CANCELLED` |

## 为什么修在 `StreamTaskManager` 而不是回调链上

这是本 PR 唯一需要讨论的设计点。

取消信号在 provider client 层就被 `ForwardingStreamCallback.finishExternally` 拦截了（注释写明「外部路径（如 cancel）触发收尾，不再透传 delegate」），因此外层 `StreamChatTraceRunner` 的 `traceAwareCallback` 收不到任何终态事件，`finishRun` 永不触发。

**这个「不透传」不能改**：`RoutingLLMService:163` 与 `:189` 在候选失败切换时同样调用 `handle.cancel()`，一旦透传 `onError`，failover 时第一个候选失败就会终止用户 SSE，「首包探测 + 候选切换对前端无感」的设计会被破坏。

而且即使透传，`finishExternally(false, null)` 传的是 `success=false`，`finishRun` 会写成 `ERROR` 而不是 `CANCELLED`，只是把「成功率虚高」换成「错误率虚高」。

所以 run 级终态只能由**能区分取消来源**的那一层上报，而全链路只有 `cancelLocal` 的 CAS 成功分支能确定「这是用户主动取消」。

## 关于分层的说明（请 Review 时特别看一下）

这样做的代价是：`StreamTaskManager` 原本只依赖 Redisson 与 SSE，现在多了一个 `RagTraceRecordService` 依赖，即在流控/取消组件里引入了观测组件。

考虑过的替代方案是**发布一个 Spring 事件、由 trace 侧订阅**，可以保持 `StreamTaskManager` 对观测无感知。没有采用是为了让本 PR 的改动面尽量小。

如果维护者认为分层更重要，我可以改成事件方式，请指示。

## 实现细节

1. **条件更新保证幂等**：`cancelRunByTaskId` 的更新条件是 `trace_id = ? AND status = 'RUNNING'`。当取消上报与正常终态（`onComplete` / `onError`）并发时，只有一方能生效，返回值表明本次是否真的翻转了状态。
2. **不影响取消本身**：上报放在取消动作完成之后，并用 try/catch 包住，仅 `log.warn`。trace 是旁路观测，其故障不应连累用户取消。
3. **`duration_ms` 实算**：从查出的 `start_time` 计算，而非置 0 或 NULL，使被取消的会话也具备可统计的真实耗时。
4. **trace 关闭时自动无害**：`rag.trace.enabled=false` 时没有 run 行，条件更新匹配 0 行，直接返回 false。

## 测试

新增 3 个测试类共 9 个用例，全部为纯单元测试，不依赖外部环境：

| 测试类 | 覆盖 |
|:--|:--|
| `StreamTaskManagerCancelTraceTest` | 取消时上报 / CAS 保证只上报一次 / 未注册任务不上报 / **trace 上报失败仍完成取消** |
| `RagTraceRecordServiceImplTest` | 收尾为 CANCELLED 并按 start_time 实算耗时 / **更新条件必须带 status** / 无 RUNNING 行时不更新 / 竞争失败时返回 false |
| `DashboardPerformanceCancelledTest` | 6 成功 + 2 失败 + 2 取消 ⇒ 成功率 60%（修复前为 75%） |

```
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

> 说明：仓库现有的 `RAGPromptServiceTest.includesCitationRulesFromKnowledgePrompt` 在 `main`(dc0d001) 上即为失败状态，与本 PR 无关（已在本 PR 分支外单独验证）。其余失败用例均为需要外部环境的 `@SpringBootTest`。

## 兼容性

- 无表结构变更，`t_rag_trace_run.status` 复用已有的 `CANCELLED` 取值（`RagStreamTraceSupportImpl` 已在 node 级使用）
- 无接口变更，`DashboardPerformanceVO` 字段不变
- 存量的悬挂 RUNNING 行不会被本 PR 追溯修复，仅影响新产生的数据
