### PR TITLE
feat: 未开启思考时显式传递 enable_thinking=false

### DIFF
--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
@@ -90,6 +90,8 @@ public abstract class AbstractOpenAIStyleChatClient implements ChatClient {
     protected void customizeRequestBody(JsonObject body, ChatRequest request) {
         if (Boolean.TRUE.equals(request.getThinking())) {
             body.addProperty("enable_thinking", true);
+        } else {
+            body.addProperty("enable_thinking", false);
         }
     }
 


### PR DESCRIPTION
### 改动说明
1. 修改文件：AbstractOpenAIStyleChatClient.java
2. 新增逻辑：根据 ChatRequest 的 thinking 字段，自动填充 enable_thinking 到上游请求体
   - 开启深度思考时，enable_thinking = true
   - 关闭深度思考时，enable_thinking = false

### 解决的问题
原逻辑只会在开启思考时传递 enable_thinking=true，未开启时缺少该参数，部分模型服务会默认开启思考（如Qwen3 系列模型的百炼 API），增加不必要耗时。
本次修改实现显式传递开关，统一行为。

### 自测验证
本地启动项目测试，开启/关闭思考两种场景均可正常生成带 enable_thinking 的请求体，无报错。