### PR TITLE
optimize(rewrite): 去重查询改写子问题

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
@@ -183,6 +183,8 @@ public class MultiQuestionRewriteService implements QueryRewriteService {
             }
             if (CollUtil.isEmpty(subs)) {
                 subs = List.of(rewrite);
+            } else {
+                subs = subs.stream().distinct().toList();
             }
             return new RewriteResult(rewrite, subs);
         } catch (Exception e) {
@@ -203,6 +205,7 @@ public class MultiQuestionRewriteService implements QueryRewriteService {
         }
         return parts.stream()
                 .map(s -> s.endsWith("？") || s.endsWith("?") ? s : s + "？")
+                .distinct()
                 .toList();
     }
 }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/rewrite/MultiQuestionRewriteServiceUnitTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/rewrite/MultiQuestionRewriteServiceUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.rewrite;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.infra.enums.Tier;
+import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import com.nageoffer.ai.ragent.rag.core.rewrite.MultiQuestionRewriteService;
+import com.nageoffer.ai.ragent.rag.core.rewrite.QueryTermMappingService;
+import com.nageoffer.ai.ragent.rag.core.rewrite.RewriteResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MultiQuestionRewriteServiceUnitTest {
+
+    @Test
+    void shouldDeduplicateLlmSubQuestionsInEncounterOrder() {
+        LLMService llmService = mock(LLMService.class);
+        RAGConfigProperties properties = mock(RAGConfigProperties.class);
+        QueryTermMappingService mappingService = mock(QueryTermMappingService.class);
+        PromptTemplateLoader templateLoader = mock(PromptTemplateLoader.class);
+        MultiQuestionRewriteService service = new MultiQuestionRewriteService(
+                llmService, properties, mappingService, templateLoader);
+
+        when(properties.getQueryRewriteEnabled()).thenReturn(true);
+        when(mappingService.normalize("订单流程和支付流程")).thenReturn("订单流程和支付流程");
+        when(templateLoader.load(any())).thenReturn("rewrite prompt");
+        when(llmService.chat(any(ChatRequest.class), eq(Tier.FAST))).thenReturn("""
+                {
+                  "rewrite": "订单流程和支付流程",
+                  "should_split": true,
+                  "sub_questions": [
+                    "订单流程是什么",
+                    "订单流程是什么",
+                    "支付流程怎么处理"
+                  ]
+                }
+                """);
+
+        RewriteResult result = service.rewriteWithSplit("订单流程和支付流程");
+
+        assertEquals(List.of("订单流程是什么", "支付流程怎么处理"), result.subQuestions());
+    }
+
+    @Test
+    void shouldDeduplicateRuleBasedSubQuestionsInEncounterOrder() {
+        LLMService llmService = mock(LLMService.class);
+        RAGConfigProperties properties = mock(RAGConfigProperties.class);
+        QueryTermMappingService mappingService = mock(QueryTermMappingService.class);
+        PromptTemplateLoader templateLoader = mock(PromptTemplateLoader.class);
+        MultiQuestionRewriteService service = new MultiQuestionRewriteService(
+                llmService, properties, mappingService, templateLoader);
+
+        String question = "订单流程？订单流程？支付流程？";
+        when(properties.getQueryRewriteEnabled()).thenReturn(false);
+        when(mappingService.normalize(question)).thenReturn(question);
+
+        RewriteResult result = service.rewriteWithSplit(question);
+
+        assertEquals(List.of("订单流程？", "支付流程？"), result.subQuestions());
+    }
+}


### PR DESCRIPTION
## 变更内容

- 对 LLM 返回的 `sub_questions` 做稳定去重，保留首次出现顺序
- 对关闭查询改写时的规则拆分结果执行相同去重
- 增加离线单元测试，覆盖 LLM JSON 和规则拆分两条路径

## 原因

PR #69 已避免同一子问题在多个意图或 Collection 的 fan-out 检索中重复生成 Query Embedding，但查询改写阶段仍可能产出精确重复的子问题。重复项会分别进入意图分类、Embedding、检索、Rerank 和上下文拼装，造成整条子链重复执行。

本 PR 在查询改写边界消除精确重复项，不做语义相似判断，也不改变现有拆分策略。

## 影响

- 相同子问题只执行一次后续处理
- 不同子问题及原有顺序保持不变
- 不引入新依赖

## 验证

```text
.\mvnw.cmd -pl bootstrap -am -Dtest=MultiQuestionRewriteServiceUnitTest -Dsurefire.failIfNoSpecifiedTests=false test
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Closes #83
