### PR TITLE
fix(ingestion): 未知或畸形节点条件结构 fail-closed

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluator.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluator.java
@@ -46,6 +46,44 @@ public class ConditionEvaluator {
     }
 
     public boolean evaluate(IngestionContext context, JsonNode condition) {
+        return isStructurallyValid(condition) && evaluateValid(context, condition);
+    }
+
+    private boolean isStructurallyValid(JsonNode condition) {
+        if (condition == null || condition.isNull() || condition.isBoolean() || condition.isTextual()) {
+            return true;
+        }
+        if (!condition.isObject()) {
+            return false;
+        }
+        if (condition.has("all")) {
+            return isStructurallyValidGroup(condition.get("all"));
+        }
+        if (condition.has("any")) {
+            return isStructurallyValidGroup(condition.get("any"));
+        }
+        if (condition.has("not")) {
+            return isStructurallyValid(condition.get("not"));
+        }
+        if (condition.has("field")) {
+            return StringUtils.hasText(condition.path("field").asText(null));
+        }
+        return false;
+    }
+
+    private boolean isStructurallyValidGroup(JsonNode node) {
+        if (node == null || !node.isArray()) {
+            return false;
+        }
+        for (JsonNode item : node) {
+            if (!isStructurallyValid(item)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean evaluateValid(IngestionContext context, JsonNode condition) {
         if (condition == null || condition.isNull()) {
             return true;
         }
@@ -63,21 +101,21 @@ public class ConditionEvaluator {
                 return evalAny(context, condition.get("any"));
             }
             if (condition.has("not")) {
-                return !evaluate(context, condition.get("not"));
+                return !evaluateValid(context, condition.get("not"));
             }
             if (condition.has("field")) {
                 return evalRule(context, condition);
             }
         }
-        return true;
+        return false;
     }
 
     private boolean evalAll(IngestionContext context, JsonNode node) {
         if (node == null || !node.isArray()) {
-            return true;
+            return false;
         }
         for (JsonNode item : node) {
-            if (!evaluate(context, item)) {
+            if (!evaluateValid(context, item)) {
                 return false;
             }
         }
@@ -86,10 +124,10 @@ public class ConditionEvaluator {
 
     private boolean evalAny(IngestionContext context, JsonNode node) {
         if (node == null || !node.isArray()) {
-            return true;
+            return false;
         }
         for (JsonNode item : node) {
-            if (evaluate(context, item)) {
+            if (evaluateValid(context, item)) {
                 return true;
             }
         }
@@ -99,7 +137,7 @@ public class ConditionEvaluator {
     private boolean evalRule(IngestionContext context, JsonNode node) {
         String field = node.path("field").asText(null);
         if (!StringUtils.hasText(field)) {
-            return true;
+            return false;
         }
         String operator = node.path("operator").asText("eq");
         JsonNode valueNode = node.get("value");

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluatorTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/ConditionEvaluatorTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class ConditionEvaluatorTest {
@@ -116,5 +117,116 @@ class ConditionEvaluatorTest {
                 .put("operator", operator);
         rule.set("value", objectMapper.valueToTree(right));
         return rule;
+    }
+
+    @Test
+    void unknownObjectConditionFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+        ObjectNode malformed = objectMapper.createObjectNode()
+                .put("fields", "rawText")
+                .put("operator", "eq")
+                .put("value", "x");
+
+        assertFalse(evaluator.evaluate(context, malformed));
+    }
+
+    @Test
+    void nonArrayAnyFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+        ObjectNode nonArrayAny = objectMapper.createObjectNode();
+        nonArrayAny.put("any", "not-an-array");
+        assertFalse(evaluator.evaluate(context, nonArrayAny));
+
+        ObjectNode emptyAny = objectMapper.createObjectNode();
+        emptyAny.set("any", objectMapper.createArrayNode());
+        assertFalse(evaluator.evaluate(context, emptyAny));
+    }
+
+    @Test
+    void nonArrayAllFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+        ObjectNode nonArrayAll = objectMapper.createObjectNode();
+        nonArrayAll.put("all", "not-an-array");
+        assertFalse(evaluator.evaluate(context, nonArrayAll));
+    }
+
+    @Test
+    void malformedConditionInsideNotFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+
+        ObjectNode notUnknown = objectMapper.createObjectNode();
+        notUnknown.set("not", objectMapper.createObjectNode()
+                .put("fields", "rawText").put("operator", "eq").put("value", "x"));
+        assertFalse(evaluator.evaluate(context, notUnknown));
+
+        ObjectNode notNonArrayAll = objectMapper.createObjectNode();
+        notNonArrayAll.set("not", objectMapper.createObjectNode().put("all", "not-an-array"));
+        assertFalse(evaluator.evaluate(context, notNonArrayAll));
+
+        ObjectNode notNonArrayAny = objectMapper.createObjectNode();
+        notNonArrayAny.set("not", objectMapper.createObjectNode().put("any", "not-an-array"));
+        assertFalse(evaluator.evaluate(context, notNonArrayAny));
+    }
+
+    @Test
+    void validNotConditionStillNegates() {
+        IngestionContext context = IngestionContext.builder().build();
+
+        ObjectNode notTrue = objectMapper.createObjectNode();
+        notTrue.set("not", objectMapper.getNodeFactory().booleanNode(true));
+        assertFalse(evaluator.evaluate(context, notTrue));
+
+        ObjectNode notFalse = objectMapper.createObjectNode();
+        notFalse.set("not", objectMapper.getNodeFactory().booleanNode(false));
+        assertTrue(evaluator.evaluate(context, notFalse));
+    }
+
+    @Test
+    void blankOrNullFieldFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+
+        ObjectNode blankField = objectMapper.createObjectNode()
+                .put("field", "").put("operator", "eq").put("value", "x");
+        assertFalse(evaluator.evaluate(context, blankField));
+
+        ObjectNode nullField = objectMapper.createObjectNode()
+                .put("operator", "eq").put("value", "x");
+        nullField.putNull("field");
+        assertFalse(evaluator.evaluate(context, nullField));
+    }
+
+    @Test
+    void malformedNestedGroupInsideNotFailsClosed() {
+        IngestionContext context = IngestionContext.builder().build();
+        ObjectNode malformed = objectMapper.createObjectNode().put("fields", "rawText");
+
+        ObjectNode any = objectMapper.createObjectNode();
+        any.set("any", objectMapper.createArrayNode().add(true).add(malformed));
+        ObjectNode notAny = objectMapper.createObjectNode();
+        notAny.set("not", any);
+        assertFalse(evaluator.evaluate(context, notAny));
+
+        ObjectNode all = objectMapper.createObjectNode();
+        all.set("all", objectMapper.createArrayNode().add(false).add(malformed));
+        ObjectNode notAll = objectMapper.createObjectNode();
+        notAll.set("not", all);
+        assertFalse(evaluator.evaluate(context, notAll));
+    }
+
+    @Test
+    void validGroupConditionsKeepShortCircuiting() {
+        IngestionContext context = IngestionContext.builder().rawText("text").build();
+        ObjectNode invalidRegex = objectMapper.createObjectNode()
+                .put("field", "rawText")
+                .put("operator", "regex")
+                .put("value", "[");
+
+        ObjectNode any = objectMapper.createObjectNode();
+        any.set("any", objectMapper.createArrayNode().add(true).add(invalidRegex));
+        assertTrue(evaluator.evaluate(context, any));
+
+        ObjectNode all = objectMapper.createObjectNode();
+        all.set("all", objectMapper.createArrayNode().add(false).add(invalidRegex));
+        assertFalse(evaluator.evaluate(context, all));
     }
 }


### PR DESCRIPTION
Fixes #85

## 问题

`ConditionEvaluator` 对以下无效结构默认返回 `true`：

- 对象不含 `all`、`any`、`not` 或 `field`
- `all` 或 `any` 的值不是数组
- `field` 缺失或为空白

配置写错后，本应跳过的节点仍会执行。

## 修改

求值前递归检查条件树结构。任一子项无效时整体返回 `false`；结构合法后继续使用原有短路求值，因此 `all`、`any` 和 `not` 的正常行为不变。

本次只处理结构错误。数值转换、SpEL 和正则表达式错误不在改动范围内。

## 测试

`ConditionEvaluatorTest` 新增 8 个用例，覆盖未知键、非数组分组、空白字段、`not` 嵌套无效条件，以及合法条件的短路行为。

```text
ConditionEvaluatorTest: 41/41 通过
Spotless: 通过
git diff --check: 通过
```
