### PR TITLE
fix(chat): 会话消息列表追加 id 决胜键保证顺序稳定

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/ConversationMessageServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/ConversationMessageServiceImpl.java
@@ -79,6 +79,7 @@ public class ConversationMessageServiceImpl implements ConversationMessageServic
                         .eq(ConversationMessageDO::getUserId, userId)
                         .eq(ConversationMessageDO::getDeleted, 0)
                         .orderBy(true, asc, ConversationMessageDO::getCreateTime)
+                        .orderBy(true, asc, ConversationMessageDO::getId)
                         .last(limit != null, "limit " + limit)
         );
         if (records == null || records.isEmpty()) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/impl/ConversationMessageServiceImplOrderTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/impl/ConversationMessageServiceImplOrderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.nageoffer.ai.ragent.rag.dao.entity.ConversationDO;
+import com.nageoffer.ai.ragent.rag.dao.entity.ConversationMessageDO;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationMapper;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationMessageMapper;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationSummaryMapper;
+import com.nageoffer.ai.ragent.rag.enums.ConversationMessageOrder;
+import com.nageoffer.ai.ragent.rag.service.MessageFeedbackService;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConversationMessageServiceImplOrderTest {
+
+    private static final String CONVERSATION_ID = "conversation-1";
+    private static final String USER_ID = "user-1";
+
+    @Mock
+    private ConversationMessageMapper conversationMessageMapper;
+
+    @Mock
+    private ConversationSummaryMapper conversationSummaryMapper;
+
+    @Mock
+    private ConversationMapper conversationMapper;
+
+    @Mock
+    private MessageFeedbackService feedbackService;
+
+    @InjectMocks
+    private ConversationMessageServiceImpl conversationMessageService;
+
+    @BeforeAll
+    static void initLambdaCache() {
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(new Configuration(), "");
+        TableInfoHelper.initTableInfo(assistant, ConversationMessageDO.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private String captureOrderBySegment(ConversationMessageOrder order) {
+        when(conversationMapper.selectOne(any())).thenReturn(new ConversationDO());
+        when(conversationMessageMapper.selectList(any())).thenReturn(List.of());
+
+        conversationMessageService.listMessages(CONVERSATION_ID, USER_ID, 6, order);
+
+        ArgumentCaptor<LambdaQueryWrapper<ConversationMessageDO>> captor =
+                ArgumentCaptor.forClass(LambdaQueryWrapper.class);
+        org.mockito.Mockito.verify(conversationMessageMapper).selectList(captor.capture());
+        String sql = captor.getValue().getCustomSqlSegment();
+        int idx = sql.toUpperCase().indexOf("ORDER BY");
+        return idx < 0 ? "" : sql.substring(idx);
+    }
+
+    @Test
+    void descendingOrderUsesIdAsTieBreaker() {
+        String orderBy = captureOrderBySegment(ConversationMessageOrder.DESC).toLowerCase();
+        assertTrue(orderBy.matches(".*order by\\s+create_?time\\s+desc\\s*,\\s*id\\s+desc.*"),
+                "Unexpected ORDER BY: " + orderBy);
+    }
+
+    @Test
+    void ascendingOrderUsesIdAsTieBreaker() {
+        String orderBy = captureOrderBySegment(ConversationMessageOrder.ASC).toLowerCase();
+        assertTrue(orderBy.matches(".*order by\\s+create_?time\\s+asc\\s*,\\s*id\\s+asc.*"),
+                "Unexpected ORDER BY: " + orderBy);
+    }
+}


### PR DESCRIPTION
Fixes #89

## 问题

`ConversationMessageServiceImpl.listMessages` 只按 `createTime` 排序。相同时间戳下记录顺序不确定，`DESC + limit` 可能选中不同消息，反转结果后也会影响消息顺序。

## 修改

在时间排序后追加同方向的 `id` 决胜键：

```java
.orderBy(true, asc, ConversationMessageDO::getCreateTime)
.orderBy(true, asc, ConversationMessageDO::getId)
```

过滤条件、`limit`、结果反转和公开接口不变。当前雪花 ID 以等长十进制字符串保存，字典序可提供稳定的决胜顺序。

## 测试

`ConversationMessageServiceImplOrderTest` 覆盖 ASC 和 DESC，检查排序列、列顺序和方向。

```text
ConversationMessageServiceImplOrderTest: 2/2 通过
Spotless: 通过
git diff --check: 通过
```

## 索引

MySQL/InnoDB 通常可以利用二级索引中的主键。PostgreSQL 当前索引不含 `id`，可能增加排序步骤；查询范围已限定到单个用户和会话，因此本次不调整 schema。若大会话下出现计划问题，可单独评估 `(conversation_id, user_id, create_time, id)` 索引。
