### PR TITLE
fix(mq): 事务消息发送失败时清理本地事务回调

### DIFF
--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/mq/producer/DelegatingTransactionListener.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/mq/producer/DelegatingTransactionListener.java
@@ -58,6 +58,10 @@ public class DelegatingTransactionListener implements RocketMQLocalTransactionLi
         localTransactionMap.put(txId, localTransaction);
     }
 
+    void unregisterLocalTransaction(String txId) {
+        localTransactionMap.remove(txId);
+    }
+
     public void registerChecker(String topic, TransactionChecker checker) {
         checkerMap.put(topic, checker);
     }

--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/mq/producer/RocketMQProducerAdapter.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/mq/producer/RocketMQProducerAdapter.java
@@ -22,6 +22,7 @@ import com.nageoffer.ai.ragent.framework.mq.MessageWrapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.client.producer.TransactionSendResult;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.apache.rocketmq.spring.core.RocketMQTemplate;
@@ -81,8 +82,12 @@ public class RocketMQProducerAdapter implements MessageQueueProducer {
         try {
             sendResult = rocketMQTemplate.sendMessageInTransaction(topic, message, null);
         } catch (Throwable ex) {
+            transactionListener.unregisterLocalTransaction(txId);
             log.error("[生产者] {} - 事务消息发送失败，topic: {}, keys: {}", bizDesc, topic, keys, ex);
             throw ex;
+        }
+        if (sendResult.getSendStatus() != SendStatus.SEND_OK) {
+            transactionListener.unregisterLocalTransaction(txId);
         }
 
         log.info("[生产者] {} - 事务消息发送结果: {}, 本地事务状态: {}, 消息ID: {}, Keys: {}",

--- a/framework/src/test/java/com/nageoffer/ai/ragent/framework/mq/producer/RocketMQProducerAdapterTest.java
+++ b/framework/src/test/java/com/nageoffer/ai/ragent/framework/mq/producer/RocketMQProducerAdapterTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.framework.mq.producer;
+
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.client.producer.TransactionSendResult;
+import org.apache.rocketmq.spring.core.RocketMQLocalTransactionState;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RocketMQProducerAdapterTest {
+
+    private static final String TOPIC = "document-chunk";
+
+    private RocketMQTemplate rocketMQTemplate;
+    private DelegatingTransactionListener transactionListener;
+    private RocketMQProducerAdapter producerAdapter;
+
+    @BeforeEach
+    void setUp() {
+        rocketMQTemplate = mock(RocketMQTemplate.class);
+        transactionListener = new DelegatingTransactionListener();
+        producerAdapter = new RocketMQProducerAdapter(rocketMQTemplate, transactionListener);
+
+        PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+        TransactionStatus transactionStatus = mock(TransactionStatus.class);
+        when(transactionManager.getTransaction(any(TransactionDefinition.class))).thenReturn(transactionStatus);
+        ReflectionTestUtils.setField(transactionListener, "transactionManager", transactionManager);
+    }
+
+    @Test
+    void sendFailureRemovesLocalTransactionCallback() {
+        RuntimeException sendFailure = new RuntimeException("broker unavailable");
+        AtomicBoolean localTransactionInvoked = new AtomicBoolean();
+        AtomicReference<Message<?>> sentMessage = new AtomicReference<>();
+        doAnswer(invocation -> {
+            sentMessage.set(invocation.getArgument(1));
+            throw sendFailure;
+        }).when(rocketMQTemplate).sendMessageInTransaction(eq(TOPIC), any(Message.class), isNull());
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> producerAdapter.sendInTransaction(
+                        TOPIC, "message-key", "document chunk", "payload",
+                        ignored -> localTransactionInvoked.set(true)));
+
+        assertSame(sendFailure, thrown);
+        assertEquals(
+                RocketMQLocalTransactionState.ROLLBACK,
+                transactionListener.executeLocalTransaction(sentMessage.get(), null));
+        assertFalse(localTransactionInvoked.get());
+    }
+
+    @Test
+    void nonOkSendStatusRemovesLocalTransactionCallback() {
+        AtomicBoolean localTransactionInvoked = new AtomicBoolean();
+        AtomicReference<Message<?>> sentMessage = new AtomicReference<>();
+        TransactionSendResult sendResult = mock(TransactionSendResult.class);
+        when(sendResult.getSendStatus()).thenReturn(SendStatus.FLUSH_DISK_TIMEOUT);
+        doAnswer(invocation -> {
+            sentMessage.set(invocation.getArgument(1));
+            return sendResult;
+        }).when(rocketMQTemplate).sendMessageInTransaction(eq(TOPIC), any(Message.class), isNull());
+
+        producerAdapter.sendInTransaction(
+                TOPIC, "message-key", "document chunk", "payload",
+                ignored -> localTransactionInvoked.set(true));
+
+        assertEquals(
+                RocketMQLocalTransactionState.ROLLBACK,
+                transactionListener.executeLocalTransaction(sentMessage.get(), null));
+        assertFalse(localTransactionInvoked.get());
+    }
+
+    @Test
+    void cleanupIsNoOpAfterCallbackIsConsumed() {
+        RuntimeException sendFailure = new RuntimeException("end transaction failed");
+        AtomicInteger localTransactionInvocations = new AtomicInteger();
+        AtomicReference<Message<?>> sentMessage = new AtomicReference<>();
+        doAnswer(invocation -> {
+            Message<?> message = invocation.getArgument(1);
+            sentMessage.set(message);
+            assertEquals(
+                    RocketMQLocalTransactionState.COMMIT,
+                    transactionListener.executeLocalTransaction(message, null));
+            throw sendFailure;
+        }).when(rocketMQTemplate).sendMessageInTransaction(eq(TOPIC), any(Message.class), isNull());
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> producerAdapter.sendInTransaction(
+                        TOPIC, "message-key", "document chunk", "payload",
+                        ignored -> localTransactionInvocations.incrementAndGet()));
+
+        assertSame(sendFailure, thrown);
+        assertEquals(1, localTransactionInvocations.get());
+        assertEquals(
+                RocketMQLocalTransactionState.ROLLBACK,
+                transactionListener.executeLocalTransaction(sentMessage.get(), null));
+    }
+
+    @Test
+    void successfulSendConsumesCallbackOnce() {
+        AtomicBoolean localTransactionInvoked = new AtomicBoolean();
+        AtomicReference<Message<?>> sentMessage = new AtomicReference<>();
+        TransactionSendResult sendResult = mock(TransactionSendResult.class);
+        when(sendResult.getSendStatus()).thenReturn(SendStatus.SEND_OK);
+        doAnswer(invocation -> {
+            Message<?> message = invocation.getArgument(1);
+            sentMessage.set(message);
+            assertEquals(
+                    RocketMQLocalTransactionState.COMMIT,
+                    transactionListener.executeLocalTransaction(message, null));
+            return sendResult;
+        }).when(rocketMQTemplate).sendMessageInTransaction(eq(TOPIC), any(Message.class), isNull());
+
+        producerAdapter.sendInTransaction(
+                TOPIC, "message-key", "document chunk", "payload",
+                ignored -> localTransactionInvoked.set(true));
+
+        assertTrue(localTransactionInvoked.get());
+        assertEquals(
+                RocketMQLocalTransactionState.ROLLBACK,
+                transactionListener.executeLocalTransaction(sentMessage.get(), null));
+    }
+}


### PR DESCRIPTION
Fixes #91

## 问题

`sendInTransaction` 会在发送前把本地事务回调注册到 `localTransactionMap`。发送同步抛错或返回非 `SEND_OK` 时，RocketMQ 不会执行本地事务监听器，回调会一直留在 Map 中。

## 修改

- 增加 `unregisterLocalTransaction`，按 `txId` 移除未消费的回调
- 发送抛错或返回非 `SEND_OK` 时清理对应回调
- 回调已被消费时，重复清理保持 no-op

成功路径和事务状态转换不变。

## 测试

`RocketMQProducerAdapterTest` 覆盖同步异常、非 `SEND_OK`、回调已消费和正常发送。

```text
RocketMQProducerAdapterTest: 4/4 通过
Spotless: 通过
git diff --check: 通过
```
