### PR TITLE
fix(ingestion): 多起点流水线配置执行前失败

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/IngestionEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/engine/IngestionEngine.java
@@ -17,7 +17,6 @@
 
 package com.nageoffer.ai.ragent.ingestion.engine;
 
-import cn.hutool.core.util.StrUtil;
 import com.nageoffer.ai.ragent.framework.exception.ClientException;
 import com.nageoffer.ai.ragent.ingestion.domain.context.IngestionContext;
 import com.nageoffer.ai.ragent.ingestion.domain.context.NodeLog;
@@ -70,8 +69,15 @@ public class IngestionEngine {
         validatePipeline(nodeConfigMap);
 
         // 找到起始节点（没有被任何节点引用的节点）
-        String startNodeId = findStartNode(nodeConfigMap);
-        if (StrUtil.isBlank(startNodeId)) {
+        List<String> startNodeIds = findStartNodes(nodeConfigMap);
+        if (startNodeIds.isEmpty()) {
+            throw new ClientException("流水线未找到起始节点");
+        }
+        if (startNodeIds.size() > 1) {
+            throw new ClientException("流水线存在多个起始节点: " + String.join(", ", startNodeIds));
+        }
+        String startNodeId = startNodeIds.get(0);
+        if (!StringUtils.hasText(startNodeId)) {
             throw new ClientException("流水线未找到起始节点");
         }
 
@@ -140,7 +146,7 @@ public class IngestionEngine {
     /**
      * 找到起始节点（没有被任何节点引用的节点）
      */
-    private String findStartNode(Map<String, NodeConfig> nodeConfigMap) {
+    private List<String> findStartNodes(Map<String, NodeConfig> nodeConfigMap) {
         Set<String> referencedNodes = nodeConfigMap.values().stream()
                 .map(NodeConfig::getNextNodeId)
                 .filter(StringUtils::hasText)
@@ -148,8 +154,8 @@ public class IngestionEngine {
 
         return nodeConfigMap.keySet().stream()
                 .filter(nodeId -> !referencedNodes.contains(nodeId))
-                .findFirst()
-                .orElse(null);
+                .sorted(Comparator.nullsFirst(Comparator.naturalOrder()))
+                .toList();
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImpl.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImpl.java
@@ -127,6 +127,8 @@ public class IngestionTaskServiceImpl implements IngestionTaskService {
             IngestionResult result = executeInternal(pipelineId, source, bytes, mimeType, null);
             putTaskSnapshot(result);
             return result;
+        } catch (ClientException e) {
+            throw e;
         } catch (Exception e) {
             throw new ClientException("读取上传文件失败: " + e.getMessage());
         }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/IngestionEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/engine/IngestionEngineTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.ingestion.engine;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nageoffer.ai.ragent.framework.exception.ClientException;
+import com.nageoffer.ai.ragent.ingestion.domain.context.IngestionContext;
+import com.nageoffer.ai.ragent.ingestion.domain.enums.IngestionStatus;
+import com.nageoffer.ai.ragent.ingestion.domain.pipeline.NodeConfig;
+import com.nageoffer.ai.ragent.ingestion.domain.pipeline.PipelineDefinition;
+import com.nageoffer.ai.ragent.ingestion.domain.result.NodeResult;
+import com.nageoffer.ai.ragent.ingestion.node.IngestionNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IngestionEngineTest {
+
+    @Test
+    void multipleStartNodesFailBeforeAnyNodeExecutes() {
+        List<String> executedNodeIds = new ArrayList<>();
+        IngestionEngine engine = engine(executedNodeIds);
+        PipelineDefinition pipeline = PipelineDefinition.builder()
+                .nodes(List.of(
+                        node("z-root", "z-leaf"),
+                        node("a-leaf", null),
+                        node("z-leaf", null),
+                        node("a-root", "a-leaf")))
+                .build();
+
+        ClientException exception = assertThrows(
+                ClientException.class,
+                () -> engine.execute(pipeline, IngestionContext.builder().build()));
+
+        assertEquals("流水线存在多个起始节点: a-root, z-root", exception.getMessage());
+        assertEquals(List.of(), executedNodeIds);
+    }
+
+    @Test
+    void nullStartNodeIdAlongsideNormalRootFailsWithoutNpe() {
+        List<String> executedNodeIds = new ArrayList<>();
+        IngestionEngine engine = engine(executedNodeIds);
+        PipelineDefinition pipeline = PipelineDefinition.builder()
+                .nodes(List.of(
+                        node("a-root", null),
+                        node(null, null)))
+                .build();
+
+        ClientException exception = assertThrows(
+                ClientException.class,
+                () -> engine.execute(pipeline, IngestionContext.builder().build()));
+
+        assertEquals("流水线存在多个起始节点: null, a-root", exception.getMessage());
+        assertEquals(List.of(), executedNodeIds);
+    }
+
+    @Test
+    void blankStartNodeIdIsRejectedBeforeExecution() {
+        List<String> executedNodeIds = new ArrayList<>();
+        IngestionEngine engine = engine(executedNodeIds);
+        PipelineDefinition pipeline = PipelineDefinition.builder()
+                .nodes(List.of(node(" ", null)))
+                .build();
+
+        ClientException exception = assertThrows(
+                ClientException.class,
+                () -> engine.execute(pipeline, IngestionContext.builder().build()));
+
+        assertEquals("流水线未找到起始节点", exception.getMessage());
+        assertEquals(List.of(), executedNodeIds);
+    }
+
+    @Test
+    void singleChainStillExecutesEveryNodeInOrder() {
+        List<String> executedNodeIds = new ArrayList<>();
+        IngestionEngine engine = engine(executedNodeIds);
+        PipelineDefinition pipeline = PipelineDefinition.builder()
+                .nodes(List.of(
+                        node("middle", "leaf"),
+                        node("leaf", null),
+                        node("root", "middle")))
+                .build();
+        IngestionContext context = IngestionContext.builder().build();
+
+        engine.execute(pipeline, context);
+
+        assertEquals(List.of("root", "middle", "leaf"), executedNodeIds);
+        assertEquals(IngestionStatus.COMPLETED, context.getStatus());
+    }
+
+    private IngestionEngine engine(List<String> executedNodeIds) {
+        IngestionNode node = new IngestionNode() {
+            @Override
+            public String getNodeType() {
+                return "test";
+            }
+
+            @Override
+            public NodeResult execute(IngestionContext context, NodeConfig config) {
+                executedNodeIds.add(config.getNodeId());
+                return NodeResult.ok();
+            }
+        };
+        return new IngestionEngine(
+                List.of(node),
+                new ConditionEvaluator(new ObjectMapper()),
+                new NodeOutputExtractor());
+    }
+
+    private NodeConfig node(String nodeId, String nextNodeId) {
+        return NodeConfig.builder()
+                .nodeId(nodeId)
+                .nodeType("test")
+                .nextNodeId(nextNodeId)
+                .build();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImplTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/ingestion/service/impl/IngestionTaskServiceImplTest.java
@@ -19,12 +19,14 @@ package com.nageoffer.ai.ragent.ingestion.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nageoffer.ai.ragent.audit.support.BizChangeLogContext;
+import com.nageoffer.ai.ragent.framework.exception.ClientException;
 import com.nageoffer.ai.ragent.ingestion.controller.vo.IngestionTaskNodeVO;
 import com.nageoffer.ai.ragent.ingestion.controller.vo.IngestionTaskVO;
 import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionTaskDO;
 import com.nageoffer.ai.ragent.ingestion.dao.entity.IngestionTaskNodeDO;
 import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionTaskMapper;
 import com.nageoffer.ai.ragent.ingestion.dao.mapper.IngestionTaskNodeMapper;
+import com.nageoffer.ai.ragent.ingestion.domain.pipeline.PipelineDefinition;
 import com.nageoffer.ai.ragent.ingestion.engine.IngestionEngine;
 import com.nageoffer.ai.ragent.ingestion.service.IngestionPipelineService;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,13 +34,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -129,5 +136,18 @@ class IngestionTaskServiceImplTest {
 
         task.setMetadataJson("null");
         assertTrue(service.get("task-1").getMetadata().isEmpty());
+    }
+
+    @Test
+    void uploadPropagatesEngineClientExceptionWithoutWrapping() {
+        ClientException engineFailure = new ClientException("流水线存在多个起始节点: a-root, z-root");
+        when(pipelineService.getDefinition("pipeline-1")).thenReturn(mock(PipelineDefinition.class));
+        when(engine.execute(any(), any())).thenThrow(engineFailure);
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "doc.txt", "text/plain", "hello".getBytes(StandardCharsets.UTF_8));
+
+        ClientException thrown = assertThrows(ClientException.class, () -> service.upload("pipeline-1", file));
+
+        assertSame(engineFailure, thrown);
     }
 }


### PR DESCRIPTION
Fixes #95

## 问题

`IngestionEngine` 原先从所有未被引用的节点中取第一个作为起点。配置存在多个起点时，只会执行其中一条链，其余节点被跳过，任务仍可能成功。

## 修改

- 收集并排序全部起点
- 多于一个起点时，在执行节点前抛出配置错误
- 没有有效起点时保留原有错误
- 单一起点继续使用现有执行流程
- upload 路径原样透传引擎抛出的 `ClientException`

## 测试

`IngestionEngineTest` 覆盖多起点、null 或空白起点，以及合法单链。`IngestionTaskServiceImplTest` 覆盖 upload 路径的异常透传。

```text
IngestionEngineTest: 4/4 通过
相关 Pipeline / Task 回归测试: 5/5 通过
Spotless: 通过
git diff --check: 通过
```

本次只让现有的单起点约束显式失败，不增加 DAG 或多入口执行。校验仍发生在执行阶段，不包含配置保存阶段的校验。
