### PR TITLE
docs(readme): 补充 Parallel Search MCP 配置示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,22 @@ Ragent 不是为了用设计模式而用，每个模式都对应一个具体的�
 
 扩展的改动主要收敛在新实现和配置中，不必复制一套检索、会话或 Trace 主链路。
 
+#### 通过 MCP 接入联网搜索
+
+如需在不注册账号、配置 API Key 的情况下增加实时网页搜索和 URL 内容提取，可以在现有 `rag.mcp.servers` 列表中添加 Parallel Search MCP：
+
+```yaml
+rag:
+  mcp:
+    servers:
+      - name: default
+        url: http://localhost:9099
+      - name: parallel-search
+        url: https://search.parallel.ai/mcp
+```
+
+应用启动后会自动发现该服务提供的 `web_search` 和 `web_fetch` 工具；这一可选服务器与现有 MCP Server 共存，不替换现有检索通道。
+
 ### 4. 生产级特性
 
 这里的生产级特性指项目已经实现生产环境会遇到的关键机制，而不只是功能能跑：


### PR DESCRIPTION
README 目前提到支持外部 MCP Server，但没有可直接参考的配置。这个补充让希望使用实时网页搜索和 URL 内容提取的用户，可以直接沿用现有的 `rag.mcp.servers` 接口。

## What changed

- 添加一个可选的 Parallel Search MCP 配置示例，同时保留现有本地 MCP Server
- 说明该端点无需账号或 API Key，并会发现 `web_search` 和 `web_fetch` 工具
- 明确这一服务器与现有 MCP Server 共存，不替换现有检索通道

## Validation

- `git diff --check`
- 对照 `McpClientProperties` 和 `McpClientAutoConfiguration` 检查配置层级、URL 处理和工具发现路径
- 仅修改 README，未运行 Maven 或前端构建

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.