### PR TITLE
fix(chat): 拒绝空白 LLM 响应并触发模型降级

### DIFF
--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/AbstractOpenAIStyleChatClient.java
@@ -325,6 +325,10 @@ public abstract class AbstractOpenAIStyleChatClient implements ChatClient {
         if (message == null || !message.has("content") || message.get("content").isJsonNull()) {
             throw new ModelClientException(provider() + " 响应缺少 content", ModelClientErrorType.INVALID_RESPONSE, null);
         }
-        return message.get("content").getAsString();
+        String content = message.get("content").getAsString();
+        if (content.isBlank()) {
+            throw new ModelClientException(provider() + " 响应 content 为空白", ModelClientErrorType.INVALID_RESPONSE, null);
+        }
+        return content;
     }
 }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/OpenAIStyleSseParser.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/OpenAIStyleSseParser.java
@@ -104,7 +104,7 @@ public final class OpenAIStyleSseParser {
         }
 
         boolean hasContent() {
-            return content != null && !content.isEmpty();
+            return content != null && !content.isBlank();
         }
 
         boolean hasReasoning() {

--- a/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/chat/OpenAIStyleSseParserTest.java
+++ b/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/chat/OpenAIStyleSseParserTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.chat;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenAIStyleSseParserTest {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void normalContentShouldBeRecognizedAsContent() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"你好\"}}]}", GSON, false);
+        assertTrue(event.hasContent());
+        assertEquals("你好", event.content());
+        assertFalse(event.completed());
+    }
+
+    @Test
+    void emptyContentShouldNotBeRecognizedAsContent() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"\"}}]}", GSON, false);
+        assertFalse(event.hasContent());
+    }
+
+    @Test
+    void blankContentShouldNotBeRecognizedAsContent() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"   \"}}]}", GSON, false);
+        assertFalse(event.hasContent());
+    }
+
+    @Test
+    void completionWithoutContentShouldBeMarkedCompleted() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine(
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}", GSON, false);
+        assertFalse(event.hasContent());
+        assertTrue(event.completed());
+    }
+
+    @Test
+    void reasoningOnlyShouldNotBeRecognizedAsContent() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine(
+                "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"思考中\"}}]}", GSON, true);
+        assertTrue(event.hasReasoning());
+        assertFalse(event.hasContent());
+    }
+
+    @Test
+    void doneMarkerShouldBeRecognized() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine("data: [DONE]", GSON, false);
+        assertFalse(event.hasContent());
+        assertTrue(event.completed());
+    }
+
+    @Test
+    void blankLineShouldReturnEmptyEvent() {
+        OpenAIStyleSseParser.ParsedEvent event = OpenAIStyleSseParser.parseLine("", GSON, false);
+        assertFalse(event.hasContent());
+        assertFalse(event.hasReasoning());
+        assertFalse(event.completed());
+    }
+}


### PR DESCRIPTION
## Summary
- 同步响应：content 为空串或纯空白时抛 INVALID_RESPONSE，触发已有 fallback（ModelRoutingExecutor 自动切换候选模型）
- 流式解析：OpenAIStyleSseParser.hasContent() 改用 isBlank()，纯空白分片不再认定为有效正文，无内容完成时走 NO_CONTENT 切换模型
- 新增 OpenAIStyleSseParserTest（空串/纯空白/正常内容/无内容完成/仅 reasoning/[DONE]/空行 共 7 个用例）

## 改动范围
- 生产代码 2 处共 6 行，仅 infra-ai 响应验证层
- 1 个测试文件
- 不涉及降级执行层（机制已存在）

## Test plan
- mvn -pl infra-ai -am test：7/7 通过
- spotless:check 通过

Related to #101
Related to #93