### PR TITLE
fix(intent): prevent Redis cache deserialization failure

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/intent/IntentNode.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/intent/IntentNode.java
@@ -18,6 +18,7 @@
 package com.nageoffer.ai.ragent.rag.core.intent;
 
 import cn.hutool.core.util.StrUtil;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nageoffer.ai.ragent.rag.enums.IntentKind;
 import com.nageoffer.ai.ragent.rag.enums.IntentLevel;
 import lombok.Builder;
@@ -167,6 +168,7 @@ public class IntentNode {
      * 返回当前意图实际参与检索的 Collection
      * 新字段优先，旧的单 Collection 字段仅作平滑升级兜底
      */
+    @JsonIgnore
     public List<String> getEffectiveCollectionNames() {
         LinkedHashSet<String> normalized = new LinkedHashSet<>();
         if (collectionNames != null) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/intent/IntentNodeJsonTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/intent/IntentNodeJsonTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.intent;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class IntentNodeJsonTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    @Test
+    void roundTripsCollectionNamesWithoutSerializingComputedProperty() throws Exception {
+        IntentNode node = IntentNode.builder()
+                .id("insurance")
+                .collectionNames(List.of("insurance", " claims ", "insurance"))
+                .build();
+
+        String json = objectMapper.writeValueAsString(node);
+        IntentNode restored = objectMapper.readValue(json, IntentNode.class);
+
+        assertFalse(json.contains("effectiveCollectionNames"));
+        assertEquals(List.of("insurance", "claims"), restored.getEffectiveCollectionNames());
+    }
+
+    @Test
+    void ignoresComputedPropertyFromExistingCacheEntry() throws Exception {
+        String json = """
+                {
+                  "id": "insurance",
+                  "collectionNames": ["insurance"],
+                  "effectiveCollectionNames": ["stale"]
+                }
+                """;
+
+        IntentNode restored = objectMapper.readValue(json, IntentNode.class);
+
+        assertEquals(List.of("insurance"), restored.getEffectiveCollectionNames());
+    }
+}


### PR DESCRIPTION
## 问题

`IntentNode#getEffectiveCollectionNames()` 是计算属性。Jackson 会把它序列化进 Redis 缓存，并在反序列化时尝试向该 getter 返回的不可变列表写入元素，从而触发 `UnsupportedOperationException`，导致意图树缓存失效并回退数据库。

## 修复

- 使用 `@JsonIgnore` 排除计算属性，保留 `collectionNames` / `collectionName` 作为缓存源字段
- 增加新缓存 round-trip 回归测试
- 增加包含旧 `effectiveCollectionNames` 字段的缓存兼容测试

## 验证

- `IntentNodeJsonTest`: 2 passed
- 无外部服务依赖的单元测试组: 104 passed, 1 skipped
- 全模块 `package -DskipTests`: success

Fixes #98