### PR TITLE
fix(rag): 修复多意图检索 Chunk 归属丢失

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/ContextFormatter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/ContextFormatter.java
@@ -23,6 +23,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 上下文格式化器，负责将知识库检索结果和 MCP 工具调用结果格式化为可嵌入 Prompt 的文本
@@ -32,12 +33,16 @@ public interface ContextFormatter {
     /**
      * 格式化知识库检索上下文
      *
-     * @param kbIntents        知识库意图节点及其得分列表
-     * @param rerankedByIntent 按意图分组的重排序后检索文档块
-     * @param contextTopK      最终进 LLM 的文档块条数上限（检索预算的 contextTopK 段）
+     * @param kbIntents         知识库意图节点及其得分列表
+     * @param retrievedIntentIds 有明确文档归属的意图 ID
+     * @param rerankedChunks    后处理后的有序文档块
+     * @param contextTopK       最终进 LLM 的文档块条数上限（检索预算的 contextTopK 段）
      * @return 格式化后的知识库上下文文本
      */
-    String formatKbContext(List<NodeScore> kbIntents, Map<String, List<RetrievedChunk>> rerankedByIntent, int contextTopK);
+    String formatKbContext(List<NodeScore> kbIntents,
+                           Set<String> retrievedIntentIds,
+                           List<RetrievedChunk> rerankedChunks,
+                           int contextTopK);
 
     /**
      * 格式化 MCP 工具调用上下文

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
@@ -20,6 +20,7 @@ package com.nageoffer.ai.ragent.rag.core.prompt;
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.util.StrUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -32,6 +33,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -44,36 +46,50 @@ public class DefaultContextFormatter implements ContextFormatter {
     private final PromptTemplateLoader templateLoader;
 
     @Override
-    public String formatKbContext(List<NodeScore> kbIntents, Map<String, List<RetrievedChunk>> rerankedByIntent, int contextTopK) {
-        if (rerankedByIntent == null || rerankedByIntent.isEmpty()) {
+    public String formatKbContext(List<NodeScore> kbIntents,
+                                  Set<String> retrievedIntentIds,
+                                  List<RetrievedChunk> rerankedChunks,
+                                  int contextTopK) {
+        if (CollUtil.isEmpty(rerankedChunks)) {
             return "";
         }
-        if (CollUtil.isEmpty(kbIntents)) {
-            return formatChunksWithoutIntent(rerankedByIntent, contextTopK);
+
+        List<NodeScore> retrievedIntents = retrievedIntents(kbIntents, retrievedIntentIds);
+        if (retrievedIntents.isEmpty()) {
+            return formatChunksWithoutIntent(rerankedChunks, contextTopK);
         }
-        if (kbIntents.size() > 1) {
-            return formatMultiIntentContext(kbIntents, rerankedByIntent, contextTopK);
+        if (retrievedIntents.size() > 1) {
+            return formatMultiIntentContext(retrievedIntents, rerankedChunks, contextTopK);
         }
-        return formatSingleIntentContext(kbIntents.get(0), rerankedByIntent, contextTopK);
+        return formatSingleIntentContext(retrievedIntents.get(0), rerankedChunks, contextTopK);
+    }
+
+    private List<NodeScore> retrievedIntents(List<NodeScore> kbIntents,
+                                             Set<String> retrievedIntentIds) {
+        if (CollUtil.isEmpty(kbIntents) || CollUtil.isEmpty(retrievedIntentIds)) {
+            return List.of();
+        }
+        return kbIntents.stream()
+                .filter(nodeScore -> nodeScore != null && nodeScore.getNode() != null)
+                .filter(nodeScore -> retrievedIntentIds.contains(nodeScore.getNode().getId()))
+                .toList();
     }
 
     /**
      * 格式化单意图上下文
      */
-    private String formatSingleIntentContext(NodeScore nodeScore, Map<String, List<RetrievedChunk>> rerankedByIntent, int topK) {
-        List<RetrievedChunk> chunks = rerankedByIntent.get(nodeScore.getNode().getId());
-        if (CollUtil.isEmpty(chunks)) {
-            return "";
-        }
+    private String formatSingleIntentContext(NodeScore nodeScore, List<RetrievedChunk> rerankedChunks, int topK) {
         String snippet = StrUtil.emptyIfNull(nodeScore.getNode().getPromptSnippet()).trim();
-        String docBlocks = renderChunksGroupedByDoc(chunks, topK);
+        String docBlocks = renderChunksGroupedByDoc(distinctChunks(rerankedChunks), topK);
         return renderKbSection(renderSnippetRules(snippet), docBlocks);
     }
 
     /**
      * 格式化多意图上下文
      */
-    private String formatMultiIntentContext(List<NodeScore> kbIntents, Map<String, List<RetrievedChunk>> rerankedByIntent, int topK) {
+    private String formatMultiIntentContext(List<NodeScore> kbIntents,
+                                            List<RetrievedChunk> rerankedChunks,
+                                            int topK) {
         // 1. 合并所有意图的回答规则
         List<String> snippets = kbIntents.stream()
                 .map(ns -> ns.getNode().getPromptSnippet())
@@ -91,14 +107,7 @@ public class DefaultContextFormatter implements ContextFormatter {
         }
 
         // 2. 合并所有意图的文档片段（按 chunk id 去重，保持相关性顺序）
-        Map<String, RetrievedChunk> dedupById = new LinkedHashMap<>();
-        rerankedByIntent.values().stream()
-                .flatMap(List::stream)
-                .forEach(chunk -> {
-                    String key = StrUtil.isNotBlank(chunk.getId()) ? chunk.getId() : "__anon__" + dedupById.size();
-                    dedupById.putIfAbsent(key, chunk);
-                });
-        List<RetrievedChunk> allChunks = new ArrayList<>(dedupById.values());
+        List<RetrievedChunk> allChunks = distinctChunks(rerankedChunks);
 
         if (allChunks.isEmpty()) {
             return snippetSection;
@@ -108,29 +117,20 @@ public class DefaultContextFormatter implements ContextFormatter {
         return renderKbSection(snippetSection, docBlocks);
     }
 
-    private String formatChunksWithoutIntent(Map<String, List<RetrievedChunk>> rerankedByIntent, int topK) {
-        int limit = topK > 0 ? topK : Integer.MAX_VALUE;
-        List<RetrievedChunk> chunks = new ArrayList<>();
-        for (List<RetrievedChunk> list : rerankedByIntent.values()) {
-            if (CollUtil.isEmpty(list)) {
-                continue;
-            }
-            for (RetrievedChunk chunk : list) {
-                chunks.add(chunk);
-                if (chunks.size() >= limit) {
-                    break;
-                }
-            }
-            if (chunks.size() >= limit) {
-                break;
-            }
-        }
+    private String formatChunksWithoutIntent(List<RetrievedChunk> rerankedChunks, int topK) {
+        List<RetrievedChunk> chunks = distinctChunks(rerankedChunks);
         if (chunks.isEmpty()) {
             return "";
         }
 
         String docBlocks = renderChunksGroupedByDoc(chunks, topK);
         return renderKbSection("", docBlocks);
+    }
+
+    private List<RetrievedChunk> distinctChunks(List<RetrievedChunk> chunks) {
+        Map<String, RetrievedChunk> distinct = new LinkedHashMap<>();
+        chunks.forEach(chunk -> distinct.putIfAbsent(RetrievedChunkKey.of(chunk), chunk));
+        return new ArrayList<>(distinct.values());
     }
 
     @Override

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/PromptContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/PromptContext.java
@@ -18,13 +18,12 @@
 package com.nageoffer.ai.ragent.rag.core.prompt;
 
 import cn.hutool.core.util.StrUtil;
-import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Prompt 构建上下文，封装一次 RAG 请求中用于组装提示词的全部输入数据
@@ -59,9 +58,9 @@ public class PromptContext {
     private List<NodeScore> kbIntents;
 
     /**
-     * 意图 ID → 检索片段列表的映射，用于判断意图是否实际命中文档
+     * 有明确文档归属的意图 ID
      */
-    private Map<String, List<RetrievedChunk>> intentChunks;
+    private Set<String> retrievedIntentIds;
 
     /**
      * 是否包含 MCP 上下文

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptService.java
@@ -20,7 +20,6 @@ package com.nageoffer.ai.ragent.rag.core.prompt;
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.util.StrUtil;
 import com.nageoffer.ai.ragent.framework.convention.ChatMessage;
-import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
@@ -29,9 +28,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -106,40 +106,33 @@ public class RAGPromptService {
         return messages;
     }
 
-    private PromptPlan planPrompt(List<NodeScore> intents, Map<String, List<RetrievedChunk>> intentChunks) {
+    private PromptPlan planPrompt(List<NodeScore> intents, Set<String> retrievedIntentIds) {
         List<NodeScore> safeIntents = intents == null ? Collections.emptyList() : intents;
+        Map<String, NodeScore> eligibleById = new LinkedHashMap<>();
+        for (NodeScore intent : safeIntents) {
+            if (intent == null || intent.getNode() == null) {
+                continue;
+            }
+            String intentId = intent.getNode().getId();
+            if (CollUtil.isNotEmpty(retrievedIntentIds) && !retrievedIntentIds.contains(intentId)) {
+                continue;
+            }
+            eligibleById.putIfAbsent(intentId, intent);
+        }
+        List<NodeScore> eligibleIntents = new ArrayList<>(eligibleById.values());
 
-        // 1) 先剔除“未命中检索”的意图
-        List<NodeScore> retained = safeIntents.stream()
-                .filter(ns -> {
-                    IntentNode node = ns.getNode();
-                    String key = nodeKey(node);
-                    List<RetrievedChunk> chunks = intentChunks == null ? null : intentChunks.get(key);
-                    return CollUtil.isNotEmpty(chunks);
-                })
-                .toList();
-
-        if (retained.isEmpty()) {
-            // 没有任何可用意图：无基模板（上层可根据业务选择 fallback）
+        if (eligibleIntents.isEmpty()) {
             return new PromptPlan(Collections.emptyList(), null);
         }
 
-        // 2) 单 / 多意图的模板与片段策略
-        if (retained.size() == 1) {
-            IntentNode only = retained.get(0).getNode();
+        if (eligibleIntents.size() == 1) {
+            IntentNode only = eligibleIntents.get(0).getNode();
             String tpl = StrUtil.emptyIfNull(only.getPromptTemplate()).trim();
-
             if (StrUtil.isNotBlank(tpl)) {
-                // 单意图 + 有模板：使用模板本身
-                return new PromptPlan(retained, tpl);
-            } else {
-                // 单意图 + 无模板：走默认模板
-                return new PromptPlan(retained, null);
+                return new PromptPlan(eligibleIntents, tpl);
             }
-        } else {
-            // 多意图：统一默认模板
-            return new PromptPlan(retained, null);
         }
+        return new PromptPlan(eligibleIntents, null);
     }
 
     private PromptBuildPlan plan(PromptContext context) {
@@ -156,7 +149,7 @@ public class RAGPromptService {
     }
 
     private PromptBuildPlan planKbOnly(PromptContext context) {
-        PromptPlan plan = planPrompt(context.getKbIntents(), context.getIntentChunks());
+        PromptPlan plan = planPrompt(context.getKbIntents(), context.getRetrievedIntentIds());
         return PromptBuildPlan.builder()
                 .scene(PromptScene.KB_ONLY)
                 .baseTemplate(plan.getBaseTemplate())
@@ -246,16 +239,5 @@ public class RAGPromptService {
 
     private String renderSection(String section, Map<String, String> slots) {
         return templateLoader.renderSection(CONTEXT_FORMAT_PATH, section, slots);
-    }
-
-    // === 工具方法 ===
-
-    /**
-     * 从意图节点提取用于映射检索结果的 key
-     */
-    private static String nodeKey(IntentNode node) {
-        if (node == null) return "";
-        if (StrUtil.isNotBlank(node.getId())) return node.getId();
-        return String.valueOf(node.getId());
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/KnowledgeRetrievalResult.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/KnowledgeRetrievalResult.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieval;
+
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public record KnowledgeRetrievalResult(List<RetrievedChunk> chunks,
+                                       Map<String, Set<String>> intentIdsByChunkKey) {
+
+    public KnowledgeRetrievalResult {
+        chunks = chunks == null ? List.of() : chunks;
+        intentIdsByChunkKey = intentIdsByChunkKey == null ? Map.of() : intentIdsByChunkKey;
+    }
+
+    public static KnowledgeRetrievalResult empty() {
+        return new KnowledgeRetrievalResult(List.of(), Map.of());
+    }
+
+    public Set<String> retrievedIntentIds() {
+        Set<String> intentIds = new LinkedHashSet<>();
+        intentIdsByChunkKey.values().stream()
+                .filter(Objects::nonNull)
+                .forEach(intentIds::addAll);
+        return Collections.unmodifiableSet(intentIds);
+    }
+
+    public Map<String, List<RetrievedChunk>> groupByIntent(String globalKey) {
+        Map<String, List<RetrievedChunk>> grouped = new LinkedHashMap<>();
+        for (RetrievedChunk chunk : chunks) {
+            Set<String> intentIds = intentIdsByChunkKey.get(RetrievedChunkKey.of(chunk));
+            if (intentIds == null || intentIds.isEmpty()) {
+                grouped.computeIfAbsent(globalKey, ignored -> new ArrayList<>()).add(chunk);
+                continue;
+            }
+            for (String intentId : intentIds) {
+                grouped.computeIfAbsent(intentId, ignored -> new ArrayList<>()).add(chunk);
+            }
+        }
+        return grouped;
+    }
+}

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
@@ -19,6 +19,7 @@ package com.nageoffer.ai.ragent.rag.core.retrieval;
 
 import cn.hutool.core.collection.CollUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.framework.trace.RagTraceNode;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.RetrievalScopeResolver;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannel;
@@ -31,8 +32,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -62,28 +67,35 @@ public class MultiChannelRetrievalEngine {
      *
      * @param subIntent 子问题及其意图
      * @param budget    检索预算（召回扇出 / Rerank 候选池上限 / 最终条数）
-     * @return 检索到的 Chunk 列表
+     * @return 后处理后的 Chunk 及其意图归属
      */
     @RagTraceNode(name = "multi-channel-retrieval", type = "RETRIEVE_CHANNEL")
-    public List<RetrievedChunk> retrieveKnowledgeChannels(SubQuestionIntent subIntent, RetrievalBudget budget) {
-        // 构建检索上下文
+    public KnowledgeRetrievalResult retrieveKnowledgeChannels(SubQuestionIntent subIntent,
+                                                               RetrievalBudget budget) {
         SearchContext context = buildSearchContext(subIntent, budget);
 
-        // 【阶段1：多通道并行检索】
         List<SearchChannelResult> channelResults = executeSearchChannels(context);
         if (CollUtil.isEmpty(channelResults)) {
-            return List.of();
+            return KnowledgeRetrievalResult.empty();
         }
 
-        // 【阶段2：后置处理器链】
-        return executePostProcessors(channelResults, context);
+        List<RetrievedChunk> chunks = executePostProcessors(channelResults, context);
+        Set<String> retainedKeys = chunks.stream()
+                .map(RetrievedChunkKey::of)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Map<String, Set<String>> intentIdsByChunkKey = new LinkedHashMap<>();
+        channelResults.stream()
+                .map(SearchChannelResult::getIntentIdsByChunkKey)
+                .filter(Objects::nonNull)
+                .flatMap(attribution -> attribution.entrySet().stream())
+                .filter(entry -> retainedKeys.contains(entry.getKey()))
+                .forEach(entry -> intentIdsByChunkKey
+                        .computeIfAbsent(entry.getKey(), ignored -> new LinkedHashSet<>())
+                        .addAll(entry.getValue()));
+        return new KnowledgeRetrievalResult(chunks, intentIdsByChunkKey);
     }
 
-    /**
-     * 执行所有启用的检索通道
-     */
     private List<SearchChannelResult> executeSearchChannels(SearchContext context) {
-        // 过滤启用的通道
         // 按通道类型枚举序做稳定排序：通道并行执行、下游融合（RRF）与归因均与顺序无关，
         // 这里排序仅为日志/派发顺序稳定可复现，不承载任何检索优先级语义
         List<SearchChannel> enabledChannels = searchChannels.stream()
@@ -115,7 +127,6 @@ public class MultiChannelRetrievalEngine {
                 ))
                 .toList();
 
-        // 等待所有通道完成并统计
         int successCount = 0;
         int failureCount = 0;
         int totalChunks = 0;
@@ -125,7 +136,6 @@ public class MultiChannelRetrievalEngine {
                 .filter(Objects::nonNull)
                 .toList();
 
-        // 打印详细统计信息
         for (SearchChannelResult result : results) {
             int chunkCount = result.getChunks().size();
             totalChunks += chunkCount;
@@ -152,12 +162,8 @@ public class MultiChannelRetrievalEngine {
         return results;
     }
 
-    /**
-     * 执行后置处理器链
-     */
     private List<RetrievedChunk> executePostProcessors(List<SearchChannelResult> results,
                                                        SearchContext context) {
-        // 过滤启用的处理器并排序
         List<SearchResultPostProcessor> enabledProcessors = postProcessors.stream()
                 .filter(processor -> processor.isEnabled(context))
                 .sorted(Comparator.comparingInt(SearchResultPostProcessor::getOrder))
@@ -170,14 +176,12 @@ public class MultiChannelRetrievalEngine {
                     .collect(Collectors.toList());
         }
 
-        // 初始 Chunk 列表（所有通道的结果合并）
         List<RetrievedChunk> chunks = results.stream()
                 .flatMap(r -> r.getChunks().stream())
                 .collect(Collectors.toList());
 
         int initialSize = chunks.size();
 
-        // 依次执行处理器
         for (SearchResultPostProcessor processor : enabledProcessors) {
             try {
                 int beforeSize = chunks.size();
@@ -192,7 +196,6 @@ public class MultiChannelRetrievalEngine {
                 );
             } catch (Exception e) {
                 log.error("后置处理器 {} 执行失败，跳过该处理器", processor.getName(), e);
-                // 继续执行下一个处理器，不中断整个链
             }
         }
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
@@ -198,29 +198,18 @@ public class RetrievalEngine {
 
     private KbResult retrieveAndRerank(SubQuestionIntent intent, List<NodeScore> kbIntents, RetrievalBudget budget) {
         // 使用多通道检索引擎（是否启用全局检索由置信度阈值决定）
-        List<RetrievedChunk> chunks = multiChannelRetrievalEngine.retrieveKnowledgeChannels(intent, budget);
+        KnowledgeRetrievalResult retrievalResult =
+                multiChannelRetrievalEngine.retrieveKnowledgeChannels(intent, budget);
+        List<RetrievedChunk> chunks = retrievalResult.chunks();
 
         if (CollUtil.isEmpty(chunks)) {
             return KbResult.empty();
         }
 
-        // 按意图节点分组（用于格式化上下文）
-        Map<String, List<RetrievedChunk>> intentChunks = new LinkedHashMap<>();
+        Map<String, List<RetrievedChunk>> intentChunks = retrievalResult.groupByIntent(MULTI_CHANNEL_KEY);
 
-        // 如果有意图识别结果，按意图节点 ID 分组
-        if (CollUtil.isNotEmpty(kbIntents)) {
-            // 将所有 chunks 按意图节点 ID 分配
-            // 注意：多通道检索返回的 chunks 无法精确对应到某个意图节点
-            // 所以我们将所有 chunks 分配给每个意图节点
-            for (NodeScore ns : kbIntents) {
-                intentChunks.put(ns.getNode().getId(), chunks);
-            }
-        } else {
-            // 如果没有意图识别结果，使用特殊 key
-            intentChunks.put(MULTI_CHANNEL_KEY, chunks);
-        }
-
-        String groupedContext = contextFormatter.formatKbContext(kbIntents, intentChunks, budget.contextTopK());
+        String groupedContext = contextFormatter.formatKbContext(
+                kbIntents, retrievalResult.retrievedIntentIds(), chunks, budget.contextTopK());
         return new KbResult(groupedContext, intentChunks);
     }
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/SearchChannelResult.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/SearchChannelResult.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * 检索通道结果
@@ -48,6 +49,12 @@ public class SearchChannelResult {
      * 检索到的 Chunk 列表
      */
     private List<RetrievedChunk> chunks;
+
+    /**
+     * 仅向量定向检索填写精确归属，关键词、图谱和全局结果保持为空
+     */
+    @Builder.Default
+    private Map<String, Set<String>> intentIdsByChunkKey = Map.of();
 
     /**
      * 检索耗时（毫秒）

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannel.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannel.java
@@ -18,10 +18,10 @@
 package com.nageoffer.ai.ragent.rag.core.retrieval.channel;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrievalBudget;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
-import com.nageoffer.ai.ragent.rag.core.retrieval.postprocessor.ChannelAttribution;
 import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
 import com.nageoffer.ai.ragent.rag.core.vector.strategy.CollectionParallelRetriever;
 import com.nageoffer.ai.ragent.rag.core.vector.strategy.IntentParallelRetriever;
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -84,9 +85,12 @@ public class VectorSearchChannel implements SearchChannel {
         try {
             RetrievalScope scope = context.getRetrievalScope();
             List<RetrievedChunk> chunks;
+            Map<String, Set<String>> intentIdsByChunkKey = Map.of();
             Map<String, Object> metadata;
             if (scope.directed()) {
-                chunks = retrieveDirected(context, scope);
+                DirectedRetrieval retrieval = retrieveDirected(context, scope);
+                chunks = retrieval.chunks();
+                intentIdsByChunkKey = retrieval.intentIdsByChunkKey();
                 metadata = Map.of("scope", "directed", "topScore", scope.topScore());
             } else {
                 chunks = retrieveGlobal(context, scope);
@@ -98,6 +102,7 @@ public class VectorSearchChannel implements SearchChannel {
                     .channelType(SearchChannelType.VECTOR)
                     .channelName(getName())
                     .chunks(chunks)
+                    .intentIdsByChunkKey(intentIdsByChunkKey)
                     .latencyMs(latency)
                     .metadata(metadata)
                     .build();
@@ -122,7 +127,7 @@ public class VectorSearchChannel implements SearchChannel {
      * 定向作用域：命中意图并行检索，同时并行补一路未命中库
      * 两路共用一次 embedding、同池并发，补充路不增加通道延迟
      */
-    private List<RetrievedChunk> retrieveDirected(SearchContext context, RetrievalScope scope) {
+    private DirectedRetrieval retrieveDirected(SearchContext context, RetrievalScope scope) {
         RetrievalBudget budget = context.getBudget();
         String question = context.getMainQuestion();
         float[] queryVector = retrieverService.embedAndNormalize(question);
@@ -146,8 +151,9 @@ public class VectorSearchChannel implements SearchChannel {
                 })
                 : CompletableFuture.completedFuture(List.of());
 
-        List<RetrievedChunk> directed = distinct(intentRetriever.retrieveByIntents(
-                question, scope.intents(), budget.recallBudget(), queryVector));
+        IntentParallelRetriever.IntentRetrievalResult intentResult = intentRetriever.retrieveByIntents(
+                question, scope.intents(), budget.recallBudget(), queryVector);
+        List<RetrievedChunk> directed = distinct(intentResult.chunks());
         List<RetrievedChunk> supplement = supplementTask.join();
         List<RetrievedChunk> capped = ScopeQuota.cap(directed, quota.primary());
 
@@ -156,7 +162,9 @@ public class VectorSearchChannel implements SearchChannel {
         log.info("向量检索完成（定向），意图 top1={}，定向召回 {} 取前 {} 条（最高余弦 {}），补充 {} 库 {} 条（最高余弦 {}）",
                 scope.topScore(), directed.size(), capped.size(), topScoreOf(directed),
                 scope.supplementCollections().size(), supplement.size(), topScoreOf(supplement));
-        return merge(capped, supplement);
+        Map<String, Set<String>> attribution = retainAttribution(
+                intentResult.intentIdsByChunkKey(), capped);
+        return new DirectedRetrieval(merge(capped, supplement), attribution);
     }
 
     /**
@@ -242,9 +250,23 @@ public class VectorSearchChannel implements SearchChannel {
     private static List<RetrievedChunk> distinct(List<RetrievedChunk> chunks) {
         Map<String, RetrievedChunk> unique = new LinkedHashMap<>();
         for (RetrievedChunk chunk : chunks) {
-            unique.putIfAbsent(ChannelAttribution.keyOf(chunk), chunk);
+            unique.putIfAbsent(RetrievedChunkKey.of(chunk), chunk);
         }
         return unique.size() == chunks.size() ? chunks : List.copyOf(unique.values());
+    }
+
+    private static Map<String, Set<String>> retainAttribution(
+            Map<String, Set<String>> attribution,
+            List<RetrievedChunk> retainedChunks) {
+        Map<String, Set<String>> retained = new LinkedHashMap<>();
+        for (RetrievedChunk chunk : retainedChunks) {
+            String key = RetrievedChunkKey.of(chunk);
+            Set<String> intentIds = attribution.get(key);
+            if (intentIds != null && !intentIds.isEmpty()) {
+                retained.put(key, intentIds);
+            }
+        }
+        return retained;
     }
 
     /**
@@ -276,5 +298,9 @@ public class VectorSearchChannel implements SearchChannel {
 
     private static float scoreOf(RetrievedChunk chunk) {
         return chunk.getScore() == null ? Float.NEGATIVE_INFINITY : chunk.getScore();
+    }
+
+    private record DirectedRetrieval(List<RetrievedChunk> chunks,
+                                     Map<String, Set<String>> intentIdsByChunkKey) {
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/ChannelAttribution.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/ChannelAttribution.java
@@ -17,9 +17,8 @@
 
 package com.nageoffer.ai.ragent.rag.core.retrieval.postprocessor;
 
-import cn.hutool.core.util.StrUtil;
-import cn.hutool.crypto.digest.DigestUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelResult;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelType;
 
@@ -36,21 +35,11 @@ import java.util.Set;
  * {@link RetrievedChunk} 不携带来源通道字段（框架层 DTO 保持纯净），故按 chunk key 从不可变的
  * {@link SearchChannelResult} 反查每条证据来自哪些通道，供融合 / Rerank 打印「各通道贡献 / 存活率」的可观测日志
  * <p>
- * key 规则：优先 id，缺失时退化为文本 SHA-256，保证同一 chunk 在通道去重 / 融合 / 归因各处 key 相同；
- * 不能用 String.hashCode()——32 位哈希碰撞会把内容不同的 chunk 误判为同一来源
+ * 归因键统一由 {@link RetrievedChunkKey} 生成，避免通道去重、融合和归因采用不同的身份规则
  */
-public final class ChannelAttribution {
+final class ChannelAttribution {
 
     private ChannelAttribution() {
-    }
-
-    /**
-     * 生成 chunk 归因键，是全链路唯一的一处 chunk 身份定义
-     */
-    public static String keyOf(RetrievedChunk chunk) {
-        return StrUtil.isNotBlank(chunk.getId())
-                ? chunk.getId()
-                : DigestUtil.sha256Hex(chunk.getText() == null ? "" : chunk.getText());
     }
 
     /**
@@ -66,7 +55,7 @@ public final class ChannelAttribution {
                 continue;
             }
             for (RetrievedChunk chunk : result.getChunks()) {
-                index.computeIfAbsent(keyOf(chunk), k -> EnumSet.noneOf(SearchChannelType.class))
+                index.computeIfAbsent(RetrievedChunkKey.of(chunk), k -> EnumSet.noneOf(SearchChannelType.class))
                         .add(result.getChannelType());
             }
         }
@@ -80,7 +69,7 @@ public final class ChannelAttribution {
                                                           Map<String, Set<SearchChannelType>> index) {
         Map<SearchChannelType, Integer> counts = new EnumMap<>(SearchChannelType.class);
         for (RetrievedChunk chunk : chunks) {
-            Set<SearchChannelType> channels = index.get(keyOf(chunk));
+            Set<SearchChannelType> channels = index.get(RetrievedChunkKey.of(chunk));
             if (channels == null) {
                 continue;
             }
@@ -98,7 +87,7 @@ public final class ChannelAttribution {
                                Map<String, Set<SearchChannelType>> index,
                                SearchChannelType channel) {
         return chunks.stream()
-                .map(ChannelAttribution::keyOf)
+                .map(RetrievedChunkKey::of)
                 .map(index::get)
                 .filter(set -> set != null && set.contains(channel))
                 .count();

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/DeduplicationPostProcessor.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/DeduplicationPostProcessor.java
@@ -18,9 +18,9 @@
 package com.nageoffer.ai.ragent.rag.core.retrieval.postprocessor;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelResult;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchContext;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -31,10 +31,9 @@ import java.util.Map;
 /**
  * 去重后置处理器
  * <p>
- * 合并多个通道的结果并按 key 去重：同一 Chunk 多路命中时保留首次出现的实例
- * 不在此处比较跨通道分数（量纲不可比），最终名次统一交由下游 RRF 融合赋分
+ * 合并多个通道的结果并按 key 去重，同一 Chunk 多路命中时保留首次出现的实例
+ * 不比较跨通道原始分数，最终名次由下游 RRF 融合赋分
  */
-@Slf4j
 @Component
 public class DeduplicationPostProcessor implements SearchResultPostProcessor {
 
@@ -45,25 +44,22 @@ public class DeduplicationPostProcessor implements SearchResultPostProcessor {
 
     @Override
     public int getOrder() {
-        return 1;  // 最先执行
+        return 1;
     }
 
     @Override
     public boolean isEnabled(SearchContext context) {
-        return true;  // 始终启用
+        return true;
     }
 
     @Override
     public List<RetrievedChunk> process(List<RetrievedChunk> chunks,
                                         List<SearchChannelResult> results,
                                         SearchContext context) {
-        // 按 key 做集合去并：同一 Chunk 多路命中时保留首次出现的实例即可
-        // 不比较各通道原始分——BM25/余弦/图谱分跨量纲不可比，且最终名次由下游 RRF 融合统一赋分
-        // 通道遍历顺序不影响结果：下游融合（RRF 累加）与归因（从 results 重算）均与顺序无关
         Map<String, RetrievedChunk> chunkMap = new LinkedHashMap<>();
         for (SearchChannelResult result : results) {
             for (RetrievedChunk chunk : result.getChunks()) {
-                chunkMap.putIfAbsent(ChannelAttribution.keyOf(chunk), chunk);
+                chunkMap.putIfAbsent(RetrievedChunkKey.of(chunk), chunk);
             }
         }
         return new ArrayList<>(chunkMap.values());

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/FusionPostProcessor.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/postprocessor/FusionPostProcessor.java
@@ -18,6 +18,7 @@
 package com.nageoffer.ai.ragent.rag.core.retrieval.postprocessor;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelResult;
 import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelType;
@@ -104,7 +105,7 @@ public class FusionPostProcessor implements SearchResultPostProcessor {
             double weight = weightOf(result.getChannelType());
             List<RetrievedChunk> channelChunks = result.getChunks();
             for (int rank = 0; rank < channelChunks.size(); rank++) {
-                String key = chunkKey(channelChunks.get(rank));
+                String key = RetrievedChunkKey.of(channelChunks.get(rank));
                 double delta = weight / (k + rank + 1);
                 rrfScores.merge(key, delta, Double::sum);
             }
@@ -112,7 +113,7 @@ public class FusionPostProcessor implements SearchResultPostProcessor {
 
         List<RetrievedChunk> fused = new ArrayList<>(chunks);
         for (RetrievedChunk chunk : fused) {
-            Double score = rrfScores.get(chunkKey(chunk));
+            Double score = rrfScores.get(RetrievedChunkKey.of(chunk));
             chunk.setScore(score != null ? score.floatValue() : 0f);
         }
         fused.sort((a, b) -> Float.compare(b.getScore(), a.getScore()));
@@ -141,14 +142,6 @@ public class FusionPostProcessor implements SearchResultPostProcessor {
                     ChannelAttribution.format(ChannelAttribution.countByChannel(candidates, index)));
         }
         return candidates;
-    }
-
-    /**
-     * 生成 Chunk 融合键 复用统一的归因键规则（优先 id，缺失时退化为文本 SHA-256），
-     * 保证融合累分与归因反查用的是同一套 key
-     */
-    private String chunkKey(RetrievedChunk chunk) {
-        return ChannelAttribution.keyOf(chunk);
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/AbstractParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/AbstractParallelRetriever.java
@@ -78,6 +78,20 @@ public abstract class AbstractParallelRetriever<T> {
                                                                List<T> targets,
                                                                int topK,
                                                                float[] queryVector) {
+        return executeParallelRetrievalDetailed(question, targets, topK, queryVector).chunks();
+    }
+
+    protected final ParallelRetrievalResult<T> executeParallelRetrievalDetailed(String question,
+                                                                                 List<T> targets,
+                                                                                 int topK) {
+        return executeParallelRetrievalDetailed(
+                question, targets, topK, retrieverService.embedAndNormalize(question));
+    }
+
+    protected final ParallelRetrievalResult<T> executeParallelRetrievalDetailed(String question,
+                                                                                 List<T> targets,
+                                                                                 int topK,
+                                                                                 float[] queryVector) {
         // 1. 创建 Future 列表
         record RetrievalFuture<T>(T target, CompletableFuture<List<RetrievedChunk>> future) {
         }
@@ -94,6 +108,7 @@ public abstract class AbstractParallelRetriever<T> {
 
         // 2. 收集结果并统计成功/失败数
         List<RetrievedChunk> allChunks = new ArrayList<>();
+        List<TargetRetrievalResult<T>> targetResults = new ArrayList<>();
         int successCount = 0;
         int failureCount = 0;
 
@@ -101,9 +116,11 @@ public abstract class AbstractParallelRetriever<T> {
             try {
                 List<RetrievedChunk> chunks = future.future.join();
                 allChunks.addAll(chunks);
+                targetResults.add(new TargetRetrievalResult<>(future.target, chunks));
                 successCount++;
             } catch (Exception e) {
                 failureCount++;
+                targetResults.add(new TargetRetrievalResult<>(future.target, List.of()));
                 log.error("{} 获取检索结果失败 - 目标: {}", getStatisticsName(), getTargetIdentifier(future.target), e);
             }
         }
@@ -118,7 +135,14 @@ public abstract class AbstractParallelRetriever<T> {
         log.info("{} 检索统计 - 总目标数: {}, 成功: {}, 失败: {}, 检索到 Chunk 总数: {}",
                 getStatisticsName(), targets.size(), successCount, failureCount, allChunks.size());
 
-        return allChunks;
+        return new ParallelRetrievalResult<>(allChunks, targetResults);
+    }
+
+    protected record TargetRetrievalResult<T>(T target, List<RetrievedChunk> chunks) {
+    }
+
+    protected record ParallelRetrievalResult<T>(List<RetrievedChunk> chunks,
+                                                List<TargetRetrievalResult<T>> targetResults) {
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetriever.java
@@ -18,6 +18,7 @@
 package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
@@ -25,19 +26,24 @@ import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
-/**
- * 意图并行检索器
- * 继承模板类，实现意图特定的检索逻辑
- */
 @Slf4j
 public class IntentParallelRetriever extends AbstractParallelRetriever<IntentParallelRetriever.IntentTask> {
 
-    public record IntentTask(NodeScore nodeScore, int intentTopK) {
+    public record IntentTask(NodeScore nodeScore, int intentTopK, Set<String> intentIds) {
+
+        public IntentTask {
+            intentIds = Set.copyOf(intentIds);
+        }
+    }
+
+    public record IntentRetrievalResult(List<RetrievedChunk> chunks,
+                                        Map<String, Set<String>> intentIdsByChunkKey) {
     }
 
     public IntentParallelRetriever(VectorRetrieverService retrieverService,
@@ -46,23 +52,42 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
     }
 
     /**
-     * 按意图节点并行检索：将 NodeScore 解析为各自召回深度后委托模板方法执行
-     * （独立命名以避免与父类 {@code executeParallelRetrieval(String, List, int)} 泛型擦除后签名冲突）
+     * 按意图节点并行检索；独立命名用于避免与父类
+     * {@code executeParallelRetrieval(String, List, int)} 泛型擦除后的签名冲突
      */
-    public List<RetrievedChunk> retrieveByIntents(String question,
-                                                  List<NodeScore> targets,
-                                                  int recallBudget) {
-        return retrieveByIntents(question, targets, recallBudget, retrieverService.embedAndNormalize(question));
+    public IntentRetrievalResult retrieveByIntents(String question,
+                                                   List<NodeScore> targets,
+                                                   int recallBudget) {
+        ParallelRetrievalResult<IntentTask> result =
+                super.executeParallelRetrievalDetailed(question, buildTasks(targets, recallBudget), recallBudget);
+        return toIntentRetrievalResult(result);
     }
 
     /**
      * 按意图节点并行检索，复用调用方已算好的查询向量
      */
-    public List<RetrievedChunk> retrieveByIntents(String question,
-                                                  List<NodeScore> targets,
-                                                  int recallBudget,
-                                                  float[] queryVector) {
-        return super.executeParallelRetrieval(question, buildTasks(targets, recallBudget), recallBudget, queryVector);
+    public IntentRetrievalResult retrieveByIntents(String question,
+                                                   List<NodeScore> targets,
+                                                   int recallBudget,
+                                                   float[] queryVector) {
+        ParallelRetrievalResult<IntentTask> result = super.executeParallelRetrievalDetailed(
+                question, buildTasks(targets, recallBudget), recallBudget, queryVector);
+        return toIntentRetrievalResult(result);
+    }
+
+    private IntentRetrievalResult toIntentRetrievalResult(ParallelRetrievalResult<IntentTask> result) {
+        Map<String, Set<String>> intentIdsByChunkKey = new LinkedHashMap<>();
+        for (TargetRetrievalResult<IntentTask> targetResult : result.targetResults()) {
+            Set<String> intentIds = targetResult.target().intentIds();
+            if (intentIds.isEmpty()) {
+                continue;
+            }
+            for (RetrievedChunk chunk : targetResult.chunks()) {
+                intentIdsByChunkKey.computeIfAbsent(RetrievedChunkKey.of(chunk), ignored -> new LinkedHashSet<>())
+                        .addAll(intentIds);
+            }
+        }
+        return new IntentRetrievalResult(result.chunks(), intentIdsByChunkKey);
     }
 
     @Override
@@ -114,16 +139,10 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
     }
 
     /**
-     * 把意图节点展开为扇出任务，并按「查询身份」去重
+     * 按 collection 集合和召回深度合并等价查询，并保留全部意图归属
      * <p>
-     * 一个任务就是一次 retrieveByVector，其结果只由 collection 集合与召回深度决定（问题与查询向量在请求内恒定），
-     * 故两项相同的任务必然返回同一份候选。留着它除了白跑一次检索，还会让同一 chunk 在通道原始列表里占两个名次，
-     * 被下游 RRF 按名次累加成双倍分；顺带把通道产能也算大一倍，连累补充路名额虚高
-     * <p>
-     * 不能改按 collection 去重：一个节点的多个 collection 是一次查询里的并集范围、总共只出 topK 条，
-     * 按 collection 计数会把多库节点的产能算成 库数 × topK
-     * <p>
-     * {@link #resolveTotalDepth} 与实际扇出共用本方法，保证「通道产能」与真实查询数永不漂移
+     * 问题与查询向量在单次调用中恒定；重复查询会重复计分并虚增通道产能；多 collection 节点仍是一次并集查询，
+     * 总共只返回 topK 条；{@link #resolveTotalDepth} 与实际检索共用本方法，使通道产能与真实查询数一致
      */
     private List<IntentTask> buildTasks(List<NodeScore> targets, int recallBudget) {
         record QueryIdentity(Set<String> collections, int topK) {
@@ -132,9 +151,24 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
         for (NodeScore nodeScore : targets) {
             int intentTopK = resolveIntentTopK(nodeScore, recallBudget);
             Set<String> collections = Set.copyOf(collectionsOf(nodeScore));
-            tasks.putIfAbsent(new QueryIdentity(collections, intentTopK), new IntentTask(nodeScore, intentTopK));
+            String intentId = intentIdOf(nodeScore);
+            IntentTask task = new IntentTask(
+                    nodeScore, intentTopK, intentId == null ? Set.of() : Set.of(intentId));
+            tasks.merge(new QueryIdentity(collections, intentTopK), task, (existing, duplicate) -> {
+                Set<String> intentIds = new LinkedHashSet<>(existing.intentIds());
+                intentIds.addAll(duplicate.intentIds());
+                return new IntentTask(existing.nodeScore(), existing.intentTopK(), intentIds);
+            });
         }
         return List.copyOf(tasks.values());
+    }
+
+    private static String intentIdOf(NodeScore nodeScore) {
+        if (nodeScore == null || nodeScore.getNode() == null) {
+            return null;
+        }
+        String intentId = nodeScore.getNode().getId();
+        return intentId == null || intentId.isBlank() ? null : intentId;
     }
 
     private static List<String> collectionsOf(NodeScore nodeScore) {
@@ -146,7 +180,7 @@ public class IntentParallelRetriever extends AbstractParallelRetriever<IntentPar
 
     /**
      * 计算单个意图节点检索 TopK
-     * 节点级 node.topK 为该意图的绝对召回深度、优先；否则用统一的每通道召回条数 recallBudget
+     * 节点级 node.topK 为该意图的绝对召回深度、优先；否则使用统一的每通道召回条数 recallBudget
      */
     private int resolveIntentTopK(NodeScore nodeScore, int recallBudget) {
         if (nodeScore != null && nodeScore.getNode() != null) {

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
@@ -24,6 +24,10 @@ import lombok.Data;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.MULTI_CHANNEL_KEY;
 
 /**
  * 检索上下文（MCP + KB 结果的统一承载）
@@ -59,6 +63,15 @@ public class RetrievalContext {
      */
     public boolean hasKb() {
         return StrUtil.isNotBlank(kbContext);
+    }
+
+    public Set<String> getRetrievedIntentIds() {
+        if (intentChunks == null || intentChunks.isEmpty()) {
+            return Set.of();
+        }
+        return intentChunks.keySet().stream()
+                .filter(intentId -> !MULTI_CHANNEL_KEY.equals(intentId))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipeline.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipeline.java
@@ -226,7 +226,7 @@ public class StreamChatPipeline {
                 .kbContext(ctx.getKbContext())
                 .mcpIntents(intentGroup.mcpIntents())
                 .kbIntents(intentGroup.kbIntents())
-                .intentChunks(ctx.getIntentChunks())
+                .retrievedIntentIds(ctx.getRetrievedIntentIds())
                 .build();
 
         List<ChatMessage> messages = promptBuilder.buildStructuredMessages(

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatterTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatterTest.java
@@ -18,11 +18,13 @@
 package com.nageoffer.ai.ragent.rag.core.prompt;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
+import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.DefaultResourceLoader;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,7 +59,7 @@ class DefaultContextFormatterTest {
                 chunk("a1", "A-idx1正文", "docA", "员工手册.pdf", 1, 0.7f),
                 chunk("x0", "孤块正文", null, null, null, 0.6f));
 
-        String result = formatter().formatKbContext(List.of(), Map.of("mc", chunks), 100);
+        String result = formatter().formatKbContext(List.of(), Set.of(), chunks, 100);
 
         // 文档 A 整体在文档 B 之前（A 的最佳块排名更高），孤块最后
         assertTrue(result.indexOf("A-idx1正文") < result.indexOf("A-idx3正文"), "同文档内应按 chunkIndex 升序");
@@ -72,7 +74,8 @@ class DefaultContextFormatterTest {
         assertFalse(result.contains("报销政策"));
 
         // 孤块单独成组、无任何属性
-        assertTrue(result.contains("<content>\n孤块正文\n</content>"), "docId 缺失应渲染为无属性的独立块");
+        assertTrue(result.replace("\r\n", "\n").contains("<content>\n孤块正文\n</content>"),
+                "docId 缺失应渲染为无属性的独立块");
     }
 
     @Test
@@ -82,7 +85,7 @@ class DefaultContextFormatterTest {
                 chunk("c1", "第一块正文", "docC", "说明.txt", 1, 0.9f),
                 chunk("c2", "第二块正文", "docC", "说明.txt", 2, 0.8f));
 
-        String result = formatter().formatKbContext(List.of(), Map.of("mc", chunks), 100);
+        String result = formatter().formatKbContext(List.of(), Set.of(), chunks, 100);
 
         assertTrue(result.contains("第一块正文\n第二块正文"), "同文档块之间用单换行拼接");
     }
@@ -92,8 +95,61 @@ class DefaultContextFormatterTest {
         List<RetrievedChunk> chunks = List.of(
                 chunk("c1", "无标题正文", "docC", null, 0, 0.9f));
 
-        String result = formatter().formatKbContext(List.of(), Map.of("mc", chunks), 100);
+        String result = formatter().formatKbContext(List.of(), Set.of(), chunks, 100);
 
         assertTrue(result.contains("<content data-ragent-doc-id=\"docC\">"));
+    }
+
+    @Test
+    void keepsDifferentChunksWhenIdsAreBlank() {
+        List<RetrievedChunk> chunks = List.of(
+                chunk("", "第一块正文", "docC", null, 0, 0.9f),
+                chunk("", "第二块正文", "docC", null, 1, 0.8f));
+
+        String result = formatter().formatKbContext(List.of(), Set.of(), chunks, 100);
+
+        assertTrue(result.contains("第一块正文"));
+        assertTrue(result.contains("第二块正文"));
+    }
+
+    @Test
+    void onlyRetrievedIntentContributesSnippet() {
+        NodeScore intentA = intent("A", "SNIPPET_A");
+        NodeScore intentB = intent("B", "SNIPPET_B");
+        RetrievedChunk chunkA = chunk("chunk-a", "A的资料", "docA", null, 0, 0.9f);
+
+        String result = formatter().formatKbContext(
+                List.of(intentA, intentB),
+                Set.of("A"),
+                List.of(chunkA),
+                100
+        );
+
+        assertTrue(result.contains("SNIPPET_A"));
+        assertFalse(result.contains("SNIPPET_B"), "未召回 Chunk 的候选意图不得注入 snippet");
+        assertTrue(result.contains("A的资料"));
+    }
+
+    @Test
+    void globalEvidenceDoesNotActivateCandidateSnippet() {
+        NodeScore intentA = intent("A", "SNIPPET_A");
+        RetrievedChunk globalChunk = chunk("global", "全局资料", null, null, 0, 0.9f);
+
+        String result = formatter().formatKbContext(
+                List.of(intentA),
+                Set.of(),
+                List.of(globalChunk),
+                100
+        );
+
+        assertFalse(result.contains("SNIPPET_A"));
+        assertTrue(result.contains("全局资料"));
+    }
+
+    private NodeScore intent(String id, String snippet) {
+        return NodeScore.builder()
+                .node(IntentNode.builder().id(id).promptSnippet(snippet).build())
+                .score(0.9)
+                .build();
     }
 }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
@@ -17,7 +17,6 @@
 
 package com.nageoffer.ai.ragent.rag.core.prompt;
 
-import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
@@ -25,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.io.DefaultResourceLoader;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,7 +54,7 @@ class RAGPromptServiceTest {
         return PromptContext.builder()
                 .kbContext("<content ref=\"1\">资料</content>")
                 .kbIntents(List.of())
-                .intentChunks(Map.of())
+                .retrievedIntentIds(Set.of())
                 .build();
     }
 
@@ -70,7 +69,8 @@ class RAGPromptServiceTest {
 
         // 引用只落在正文单元末尾，标题一律不带引用，示例本身也不能出现带引用的标题
         assertTrue(result.contains("标题与小标题一律不加引用"));
-        assertTrue(result.contains("## 二级标题\n\n第一部分包含要点 A 和要点 B。[1](#cite-1)"));
+        assertTrue(result.replace("\r\n", "\n")
+                .contains("## 二级标题\n\n第一部分包含要点 A 和要点 B。[1](#cite-1)"));
         assertFalse(result.contains("## 二级标题 ["));
 
         // 同一单元依据多份资料时连写编号
@@ -105,7 +105,7 @@ class RAGPromptServiceTest {
         PromptContext context = PromptContext.builder()
                 .kbContext("<content>资料</content>")
                 .kbIntents(List.of(intentWithTemplate("# 自定义意图模板")))
-                .intentChunks(Map.of("intent-1", List.of(RetrievedChunk.builder().text("资料").build())))
+                .retrievedIntentIds(Set.of("intent-1"))
                 .build();
 
         String result = service(true).buildSystemPrompt(context);
@@ -117,13 +117,90 @@ class RAGPromptServiceTest {
     }
 
     @Test
+    void usesSingleCandidateTemplateForGlobalEvidence() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>全局资料</content>")
+                .kbIntents(List.of(intentWithTemplate("intent-1", "# 单意图模板")))
+                .retrievedIntentIds(Set.of())
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith("# 单意图模板"));
+        assertFalse(result.contains(STUB_BASE_TEMPLATE));
+    }
+
+    @Test
+    void usesExactRetrievedIntentTemplateAmongCandidates() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>意图资料</content>")
+                .kbIntents(List.of(
+                        intentWithTemplate("intent-1", "# 未命中模板"),
+                        intentWithTemplate("intent-2", "# 命中模板")))
+                .retrievedIntentIds(Set.of("intent-2"))
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith("# 命中模板"));
+        assertFalse(result.contains("# 未命中模板"));
+    }
+
+    @Test
+    void usesDefaultTemplateForMultipleCandidatesWithGlobalEvidence() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>全局资料</content>")
+                .kbIntents(List.of(
+                        intentWithTemplate("intent-1", "# 候选模板一"),
+                        intentWithTemplate("intent-2", "# 候选模板二")))
+                .retrievedIntentIds(Set.of())
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith(STUB_BASE_TEMPLATE));
+        assertFalse(result.contains("# 候选模板一"));
+        assertFalse(result.contains("# 候选模板二"));
+    }
+
+    @Test
+    void usesTemplateForDuplicateExactIntentCandidates() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>意图资料</content>")
+                .kbIntents(List.of(
+                        intentWithTemplate("intent-1", "# 单意图模板"),
+                        intentWithTemplate("intent-1", "# 单意图模板")))
+                .retrievedIntentIds(Set.of("intent-1"))
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith("# 单意图模板"));
+    }
+
+    @Test
+    void usesTemplateForDuplicateGlobalIntentCandidates() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>全局资料</content>")
+                .kbIntents(List.of(
+                        intentWithTemplate("intent-1", "# 单意图模板"),
+                        intentWithTemplate("intent-1", "# 单意图模板")))
+                .retrievedIntentIds(Set.of())
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith("# 单意图模板"));
+    }
+
+    @Test
     void includesCitationRulesFromMixedPrompt() {
         PromptContext context = PromptContext.builder()
                 .mcpContext("<data>动态数据</data>")
                 .kbContext("<content ref=\"1\">资料</content>")
                 .mcpIntents(List.of())
                 .kbIntents(List.of())
-                .intentChunks(Map.of())
+                .retrievedIntentIds(Set.of())
                 .build();
 
         String result = service(true).buildSystemPrompt(context);
@@ -146,8 +223,12 @@ class RAGPromptServiceTest {
     }
 
     private static NodeScore intentWithTemplate(String template) {
+        return intentWithTemplate("intent-1", template);
+    }
+
+    private static NodeScore intentWithTemplate(String id, String template) {
         IntentNode node = IntentNode.builder()
-                .id("intent-1")
+                .id(id)
                 .promptTemplate(template)
                 .build();
         return NodeScore.builder().node(node).build();

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieval;
+
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.RetrievalScopeResolver;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannel;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelResult;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchChannelType;
+import com.nageoffer.ai.ragent.rag.core.retrieval.channel.SearchContext;
+import com.nageoffer.ai.ragent.rag.core.retrieval.postprocessor.SearchResultPostProcessor;
+import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MultiChannelRetrievalEngineTest {
+
+    @Test
+    void filtersAttributionByFinalChunksAndKeepsGlobalEvidence() {
+        RetrievedChunk originalA = chunk(null, "A资料", 0.9F);
+        RetrievedChunk chunkA = chunk(null, "A资料", 0.9F);
+        RetrievedChunk discardedA = chunk("discarded", "被淘汰的A资料", 0.8F);
+        RetrievedChunk globalChunk = chunk("global", "全局资料", 0.7F);
+
+        SearchChannel vector = channel(
+                "vector",
+                SearchChannelType.VECTOR,
+                SearchChannelResult.builder()
+                        .channelType(SearchChannelType.VECTOR)
+                        .channelName("vector")
+                        .chunks(List.of(originalA, discardedA))
+                        .intentIdsByChunkKey(Map.of(
+                                RetrievedChunkKey.of(originalA), Set.of("A", "B"),
+                                RetrievedChunkKey.of(discardedA), Set.of("A")))
+                        .build()
+        );
+        SearchChannel keyword = channel(
+                "keyword",
+                SearchChannelType.KEYWORD,
+                SearchChannelResult.builder()
+                        .channelType(SearchChannelType.KEYWORD)
+                        .channelName("keyword")
+                        .chunks(List.of(globalChunk))
+                        .build()
+        );
+
+        SearchResultPostProcessor finalSelection = mock(SearchResultPostProcessor.class);
+        when(finalSelection.getOrder()).thenReturn(1);
+        when(finalSelection.isEnabled(any(SearchContext.class))).thenReturn(true);
+        when(finalSelection.process(anyList(), anyList(), any(SearchContext.class)))
+                .thenReturn(List.of(globalChunk, chunkA));
+
+        KnowledgeRetrievalResult result = new MultiChannelRetrievalEngine(
+                List.of(vector, keyword),
+                List.of(finalSelection),
+                mock(RetrievalScopeResolver.class),
+                Runnable::run)
+                .retrieveKnowledgeChannels(
+                        new SubQuestionIntent("问题", List.of()),
+                        RetrievalBudget.uniform(10)
+                );
+        Map<String, List<RetrievedChunk>> grouped = result.groupByIntent("multi_channel");
+
+        assertEquals(List.of(globalChunk, chunkA), result.chunks(), "不得改变最终后处理顺序");
+        assertEquals(List.of(chunkA), grouped.get("A"));
+        assertEquals(List.of(chunkA), grouped.get("B"));
+        assertEquals(List.of(globalChunk), grouped.get("multi_channel"));
+        assertEquals(Set.of("A", "B"), result.retrievedIntentIds());
+        assertFalse(result.intentIdsByChunkKey().containsKey(RetrievedChunkKey.of(discardedA)));
+    }
+
+    private SearchChannel channel(String name, SearchChannelType type, SearchChannelResult result) {
+        SearchChannel channel = mock(SearchChannel.class);
+        when(channel.getName()).thenReturn(name);
+        when(channel.getType()).thenReturn(type);
+        when(channel.isEnabled(any(SearchContext.class))).thenReturn(true);
+        when(channel.search(any(SearchContext.class))).thenReturn(result);
+        return channel;
+    }
+
+    private RetrievedChunk chunk(String id, String text, float score) {
+        return RetrievedChunk.builder().id(id).text(text).score(score).build();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieval;
+
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
+import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
+import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
+import com.nageoffer.ai.ragent.rag.core.mcp.McpParameterExtractor;
+import com.nageoffer.ai.ragent.rag.core.mcp.McpToolRegistry;
+import com.nageoffer.ai.ragent.rag.core.prompt.ContextFormatter;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import com.nageoffer.ai.ragent.rag.dto.RetrievalContext;
+import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.MULTI_CHANNEL_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RetrievalEngineTest {
+
+    @Test
+    void returnsOnlyActualIntentMatchesAndIndependentGlobalEvidence() {
+        RetrievedChunk chunkA = chunk("a", "A资料");
+        RetrievedChunk globalChunk = chunk("global", "全局资料");
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        ContextFormatter contextFormatter = mock(ContextFormatter.class);
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenReturn(new KnowledgeRetrievalResult(
+                        List.of(chunkA, globalChunk),
+                        Map.of(RetrievedChunkKey.of(chunkA), Set.of("A"))
+                ));
+
+        RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题", List.of(intent("A"), intent("B")))
+        ));
+
+        assertEquals(Map.of(
+                "A", List.of(chunkA),
+                MULTI_CHANNEL_KEY, List.of(globalChunk)
+        ), result.getIntentChunks());
+        assertEquals(Set.of("A"), result.getRetrievedIntentIds());
+        verify(contextFormatter).formatKbContext(anyList(), eq(Set.of("A")), eq(List.of(chunkA, globalChunk)), anyInt());
+    }
+
+    private RetrievalEngine engine(MultiChannelRetrievalEngine multiChannel, ContextFormatter contextFormatter) {
+        return new RetrievalEngine(
+                new SearchChannelProperties(),
+                contextFormatter,
+                mock(PromptTemplateLoader.class),
+                mock(McpParameterExtractor.class),
+                mock(McpToolRegistry.class),
+                multiChannel,
+                Runnable::run,
+                Runnable::run
+        );
+    }
+
+    private NodeScore intent(String id) {
+        return NodeScore.builder().node(IntentNode.builder().id(id).build()).score(0.9).build();
+    }
+
+    private RetrievedChunk chunk(String id, String text) {
+        return RetrievedChunk.builder().id(id).text(text).build();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannelAttributionTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/VectorSearchChannelAttributionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.retrieval.channel;
+
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
+import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
+import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
+import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrievalBudget;
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
+import com.nageoffer.ai.ragent.rag.core.vector.VectorRetrieverService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VectorSearchChannelAttributionTest {
+
+    private static final String QUESTION = "报销发票贴哪张表？";
+    private static final RetrievalBudget BUDGET = new RetrievalBudget(20, 40, 10);
+
+    private VectorRetrieverService retrieverService;
+
+    @BeforeEach
+    void setUp() {
+        retrieverService = mock(VectorRetrieverService.class);
+        when(retrieverService.embedAndNormalize(QUESTION)).thenReturn(new float[]{0.6F, 0.8F});
+        when(retrieverService.supportsGlobalRetrieval()).thenReturn(true);
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class)))
+                .thenAnswer(invocation -> chunks(invocation.getArgument(1)));
+    }
+
+    @Test
+    @DisplayName("等价定向查询保留全部意图归属")
+    void equivalentDirectedQueriesKeepAllIntentOwners() {
+        RetrievalScope scope = new RetrievalScope(true, 0.9,
+                List.of(intent("报销", "kb-finance"), intent("发票", "kb-finance")),
+                List.of("kb-finance"), List.of());
+
+        SearchChannelResult result = search(scope, BUDGET);
+
+        assertTrue(result.getChunks().stream().allMatch(chunk ->
+                Set.of("报销", "发票").equals(
+                        result.getIntentIdsByChunkKey().get(RetrievedChunkKey.of(chunk)))));
+    }
+
+    @Test
+    @DisplayName("定向截断后只保留入选证据的归属")
+    void attributionFollowsDirectedCap() {
+        RetrievalScope scope = new RetrievalScope(
+                true, 0.9, List.of(intent("kb-finance", "kb-finance")),
+                List.of("kb-finance"), List.of());
+
+        SearchChannelResult result = search(scope, new RetrievalBudget(20, 1, 1));
+
+        assertEquals(1, result.getChunks().size());
+        assertEquals(Map.of(
+                        RetrievedChunkKey.of(result.getChunks().get(0)),
+                        Set.of("kb-finance")),
+                result.getIntentIdsByChunkKey());
+    }
+
+    @Test
+    @DisplayName("补充与全局召回不写入精确意图归属")
+    void nonDirectedChunksRemainUnattributed() {
+        RetrievalScope directedScope = new RetrievalScope(
+                true, 0.9, List.of(intent("finance", "kb-finance")),
+                List.of("kb-finance"), List.of("kb-hr"));
+        SearchChannelResult directed = search(directedScope, BUDGET);
+
+        assertTrue(directed.getChunks().stream()
+                .filter(chunk -> chunk.getId().startsWith("kb-hr"))
+                .noneMatch(chunk -> directed.getIntentIdsByChunkKey()
+                        .containsKey(RetrievedChunkKey.of(chunk))));
+
+        SearchChannelResult global = search(
+                RetrievalScope.global(0.3, List.of("kb-finance")), BUDGET);
+        assertTrue(global.getIntentIdsByChunkKey().isEmpty());
+    }
+
+    private SearchChannelResult search(RetrievalScope scope, RetrievalBudget budget) {
+        SearchContext context = SearchContext.builder()
+                .originalQuestion(QUESTION)
+                .budget(budget)
+                .retrievalScope(scope)
+                .build();
+        return new VectorSearchChannel(
+                retrieverService, new SearchChannelProperties(), Runnable::run).search(context);
+    }
+
+    private static NodeScore intent(String id, String collection) {
+        return NodeScore.builder()
+                .node(IntentNode.builder()
+                        .id(id)
+                        .name(id)
+                        .collectionNames(List.of(collection))
+                        .build())
+                .score(0.9)
+                .build();
+    }
+
+    private static List<RetrievedChunk> chunks(RetrieveRequest request) {
+        String collection = request.getEffectiveCollectionNames().get(0);
+        return IntStream.range(0, request.getTopK())
+                .mapToObj(index -> RetrievedChunk.builder()
+                        .id(collection + "-" + index)
+                        .text(collection + "-" + index)
+                        .score(0.9F - index * 0.001F)
+                        .build())
+                .toList();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetrieverTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/vector/strategy/IntentParallelRetrieverTest.java
@@ -18,6 +18,7 @@
 package com.nageoffer.ai.ragent.rag.core.vector.strategy;
 
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
+import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.retrieval.RetrieveRequest;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,9 +79,78 @@ class IntentParallelRetrieverTest {
         NodeScore nodeScore = NodeScore.builder().node(node).score(0.95).build();
 
         IntentParallelRetriever retriever = new IntentParallelRetriever(retrieverService, Runnable::run);
-        List<RetrievedChunk> chunks = retriever.retrieveByIntents("如何申请？", List.of(nodeScore), 20);
+        IntentParallelRetriever.IntentRetrievalResult result =
+                retriever.retrieveByIntents("如何申请？", List.of(nodeScore), 20);
 
-        assertTrue(chunks.isEmpty());
+        assertTrue(result.chunks().isEmpty());
+        assertTrue(result.intentIdsByChunkKey().isEmpty());
         verify(retrieverService, never()).retrieveByVector(any(float[].class), any(RetrieveRequest.class));
+    }
+
+    @Test
+    @DisplayName("意图定向检索只记录真实召回归属")
+    void recordsOnlyActualIntentMatches() {
+        VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        when(retrieverService.embedAndNormalize("问题")).thenReturn(new float[]{1F});
+        RetrievedChunk chunkA = RetrievedChunk.builder().id("chunk-a").text("A资料").score(0.9F).build();
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class)))
+                .thenAnswer(invocation -> {
+                    RetrieveRequest request = invocation.getArgument(1);
+                    return request.getEffectiveCollectionNames().contains("collection-a")
+                            ? List.of(chunkA)
+                            : List.of();
+                });
+
+        IntentParallelRetriever.IntentRetrievalResult result = new IntentParallelRetriever(
+                retrieverService, Runnable::run).retrieveByIntents(
+                "问题", List.of(intent("A", "collection-a"), intent("B", "collection-b")), 10);
+
+        assertEquals(List.of(chunkA), result.chunks());
+        assertEquals(Set.of("A"), result.intentIdsByChunkKey().get(RetrievedChunkKey.of(chunkA)));
+    }
+
+    @Test
+    @DisplayName("共享 Chunk 保留全部召回意图")
+    void recordsAllIntentsForSharedChunk() {
+        VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        when(retrieverService.embedAndNormalize("问题")).thenReturn(new float[]{1F});
+        RetrievedChunk sharedChunk = RetrievedChunk.builder().id("shared").text("共享资料").score(0.9F).build();
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class)))
+                .thenReturn(List.of(sharedChunk));
+
+        IntentParallelRetriever.IntentRetrievalResult result = new IntentParallelRetriever(
+                retrieverService, Runnable::run).retrieveByIntents(
+                "问题", List.of(intent("A", "collection-a"), intent("B", "collection-b")), 10);
+
+        assertEquals(Set.of("A", "B"), result.intentIdsByChunkKey().get(RetrievedChunkKey.of(sharedChunk)));
+    }
+
+    @Test
+    @DisplayName("相同查询只执行一次并保留全部意图归属")
+    void equivalentQueriesKeepAllIntentOwners() {
+        VectorRetrieverService retrieverService = mock(VectorRetrieverService.class);
+        when(retrieverService.embedAndNormalize("问题")).thenReturn(new float[]{1F});
+        RetrievedChunk sharedChunk = RetrievedChunk.builder().id("shared").text("共享资料").score(0.9F).build();
+        when(retrieverService.retrieveByVector(any(float[].class), any(RetrieveRequest.class)))
+                .thenReturn(List.of(sharedChunk));
+
+        IntentParallelRetriever.IntentRetrievalResult result = new IntentParallelRetriever(
+                retrieverService, Runnable::run).retrieveByIntents(
+                "问题", List.of(intent("A", "collection"), intent("B", "collection")), 10);
+
+        verify(retrieverService, times(1))
+                .retrieveByVector(any(float[].class), any(RetrieveRequest.class));
+        assertEquals(Set.of("A", "B"), result.intentIdsByChunkKey().get(RetrievedChunkKey.of(sharedChunk)));
+    }
+
+    private NodeScore intent(String id, String collectionName) {
+        return NodeScore.builder()
+                .node(IntentNode.builder()
+                        .id(id)
+                        .name(id)
+                        .collectionNames(List.of(collectionName))
+                        .build())
+                .score(0.95)
+                .build();
     }
 }

--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/convention/RetrievedChunkKey.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/convention/RetrievedChunkKey.java
@@ -15,29 +15,19 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.rag.core.prompt;
+package com.nageoffer.ai.ragent.framework.convention;
 
-import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.crypto.digest.DigestUtil;
 
-import java.util.List;
+public final class RetrievedChunkKey {
 
-@Data
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Builder
-public class PromptPlan {
+    private RetrievedChunkKey() {
+    }
 
-    /**
-     * 用于选择模板的候选意图
-     */
-    private List<NodeScore> retainedIntents;
-
-    /**
-     * 选用的基模板（单意图且有模板才会有值，否则为 null 表示用默认模板）
-     */
-    private String baseTemplate;
+    public static String of(RetrievedChunk chunk) {
+        return StrUtil.isNotBlank(chunk.getId())
+                ? chunk.getId()
+                : DigestUtil.sha256Hex(chunk.getText() == null ? "" : chunk.getText());
+    }
 }

--- a/framework/src/test/java/com/nageoffer/ai/ragent/framework/convention/RetrievedChunkKeyTest.java
+++ b/framework/src/test/java/com/nageoffer/ai/ragent/framework/convention/RetrievedChunkKeyTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.framework.convention;
+
+import cn.hutool.crypto.digest.DigestUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RetrievedChunkKeyTest {
+
+    @Test
+    void prefersChunkId() {
+        RetrievedChunk chunk = RetrievedChunk.builder().id("chunk-id").text("text").build();
+
+        assertEquals("chunk-id", RetrievedChunkKey.of(chunk));
+    }
+
+    @Test
+    void hashesTextWhenIdIsMissing() {
+        RetrievedChunk chunk = RetrievedChunk.builder().text("text").build();
+
+        assertEquals(DigestUtil.sha256Hex("text"), RetrievedChunkKey.of(chunk));
+    }
+
+    @Test
+    void hashesTextWhenIdIsBlank() {
+        RetrievedChunk chunk = RetrievedChunk.builder().id(" ").text("text").build();
+
+        assertEquals(DigestUtil.sha256Hex("text"), RetrievedChunkKey.of(chunk));
+    }
+
+    @Test
+    void hashesEmptyTextWhenIdAndTextAreMissing() {
+        assertEquals(DigestUtil.sha256Hex(""), RetrievedChunkKey.of(RetrievedChunk.builder().build()));
+    }
+}


### PR DESCRIPTION
## 说明

Issue #87 的多意图检索会在并行汇总后丢失 Chunk 与召回意图的对应关系，导致未命中的意图参与 Prompt 规划。

## 改动

- 在定向向量检索中保留 Chunk 与意图的真实归属
- 等价查询只执行一次，同时保留全部意图 owner
- 后处理完成后仅保留最终入选 Chunk 的归属
- 全局证据不激活候选意图的 snippet，但仍保留分类结果对应的自定义 `promptTemplate`
- 将 `RetrievedChunkKey` 放到 framework 层，去重、融合和归因共用同一身份规则
- 接入最新 `RetrievalScope`、补充检索配额和单子问题调用结构
- 补充共享 Chunk、截断后归属、全局证据和 Prompt 选择回归测试

## 边界

精确意图归属目前由向量定向检索提供。Keyword、Graph 和全局检索没有足够信息建立精确归属，因此保持为空，不根据 Collection、文档名或内容反推。排序、RRF、Rerank、Score、TopK 和 Prompt 模板资源不变。

## 验证

- 定向回归：73 passed
- 编译：passed
- `git diff --check origin/main...7937eee`：passed
- 全仓测试：241 tests，0 failures，24 errors，2 skipped
  - 21 个 Spring 集成用例因本机 `127.0.0.1:6379` 拒绝连接而无法加载上下文
  - 3 个错误来自既有 `JdbcConversationMemorySummaryServiceTest` 的 Mockito 严格桩检查

Closes #87
