### PR TITLE
fix(rag): 区分定向检索未命中与全局回退

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/ContextFormatter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/ContextFormatter.java
@@ -34,13 +34,13 @@ public interface ContextFormatter {
      * 格式化知识库检索上下文
      *
      * @param kbIntents         知识库意图节点及其得分列表
-     * @param retrievedIntentIds 有明确文档归属的意图 ID
+     * @param eligibleIntentIds 允许注入回答规则的意图 ID
      * @param rerankedChunks    后处理后的有序文档块
      * @param contextTopK       最终进 LLM 的文档块条数上限（检索预算的 contextTopK 段）
      * @return 格式化后的知识库上下文文本
      */
     String formatKbContext(List<NodeScore> kbIntents,
-                           Set<String> retrievedIntentIds,
+                           Set<String> eligibleIntentIds,
                            List<RetrievedChunk> rerankedChunks,
                            int contextTopK);
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
@@ -49,35 +49,34 @@ public class DefaultContextFormatter implements ContextFormatter {
 
     @Override
     public String formatKbContext(List<NodeScore> kbIntents,
-                                  Set<String> retrievedIntentIds,
+                                  Set<String> eligibleIntentIds,
                                   List<RetrievedChunk> rerankedChunks,
                                   int contextTopK) {
         if (CollUtil.isEmpty(rerankedChunks)) {
             return "";
         }
 
-        List<NodeScore> retrievedIntents = retrievedIntents(kbIntents, retrievedIntentIds);
-        // 归因链路的出口观测：提示词「没生效」时靠这一行区分是归属为空还是模板/片段本身未配置
-        log.info("检索归因 - 提示词分支: {}, 归属意图: {}",
-                retrievedIntents.isEmpty() ? "无归属" : retrievedIntents.size() > 1 ? "多意图" : "单意图",
-                retrievedIntents.stream().map(ns -> ns.getNode().getName()).toList());
-        if (retrievedIntents.isEmpty()) {
+        List<NodeScore> eligibleIntents = eligibleIntents(kbIntents, eligibleIntentIds);
+        log.info("提示词规划 - 提示词分支: {}, 可用意图: {}",
+                eligibleIntents.isEmpty() ? "无可用意图" : eligibleIntents.size() > 1 ? "多意图" : "单意图",
+                eligibleIntents.stream().map(ns -> ns.getNode().getName()).toList());
+        if (eligibleIntents.isEmpty()) {
             return formatChunksWithoutIntent(rerankedChunks, contextTopK);
         }
-        if (retrievedIntents.size() > 1) {
-            return formatMultiIntentContext(retrievedIntents, rerankedChunks, contextTopK);
+        if (eligibleIntents.size() > 1) {
+            return formatMultiIntentContext(eligibleIntents, rerankedChunks, contextTopK);
         }
-        return formatSingleIntentContext(retrievedIntents.get(0), rerankedChunks, contextTopK);
+        return formatSingleIntentContext(eligibleIntents.get(0), rerankedChunks, contextTopK);
     }
 
-    private List<NodeScore> retrievedIntents(List<NodeScore> kbIntents,
-                                             Set<String> retrievedIntentIds) {
-        if (CollUtil.isEmpty(kbIntents) || CollUtil.isEmpty(retrievedIntentIds)) {
+    private List<NodeScore> eligibleIntents(List<NodeScore> kbIntents,
+                                            Set<String> eligibleIntentIds) {
+        if (CollUtil.isEmpty(kbIntents) || CollUtil.isEmpty(eligibleIntentIds)) {
             return List.of();
         }
         return kbIntents.stream()
                 .filter(nodeScore -> nodeScore != null && nodeScore.getNode() != null)
-                .filter(nodeScore -> retrievedIntentIds.contains(nodeScore.getNode().getId()))
+                .filter(nodeScore -> eligibleIntentIds.contains(nodeScore.getNode().getId()))
                 .toList();
     }
 

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatter.java
@@ -57,8 +57,13 @@ public class DefaultContextFormatter implements ContextFormatter {
         }
 
         List<NodeScore> eligibleIntents = eligibleIntents(kbIntents, eligibleIntentIds);
-        log.info("提示词规划 - 提示词分支: {}, 可用意图: {}",
-                eligibleIntents.isEmpty() ? "无可用意图" : eligibleIntents.size() > 1 ? "多意图" : "单意图",
+        String branch = switch (eligibleIntents.size()) {
+            case 0 -> "无可用意图";
+            case 1 -> "单意图";
+            default -> "多意图";
+        };
+        log.info("检索归因 - 提示词分支: {}, 可用意图: {}",
+                branch,
                 eligibleIntents.stream().map(ns -> ns.getNode().getName()).toList());
         if (eligibleIntents.isEmpty()) {
             return formatChunksWithoutIntent(rerankedChunks, contextTopK);

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/PromptContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/PromptContext.java
@@ -58,9 +58,10 @@ public class PromptContext {
     private List<NodeScore> kbIntents;
 
     /**
-     * 有明确文档归属的意图 ID
+     * 允许参与模板选择和规则注入的意图 ID
      */
-    private Set<String> retrievedIntentIds;
+    @Builder.Default
+    private Set<String> eligibleIntentIds = Set.of();
 
     /**
      * 是否包含 MCP 上下文

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptService.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptService.java
@@ -106,7 +106,7 @@ public class RAGPromptService {
         return messages;
     }
 
-    private PromptPlan planPrompt(List<NodeScore> intents, Set<String> retrievedIntentIds) {
+    private PromptPlan planPrompt(List<NodeScore> intents, Set<String> eligibleIntentIds) {
         List<NodeScore> safeIntents = intents == null ? Collections.emptyList() : intents;
         Map<String, NodeScore> eligibleById = new LinkedHashMap<>();
         for (NodeScore intent : safeIntents) {
@@ -114,7 +114,7 @@ public class RAGPromptService {
                 continue;
             }
             String intentId = intent.getNode().getId();
-            if (CollUtil.isNotEmpty(retrievedIntentIds) && !retrievedIntentIds.contains(intentId)) {
+            if (!eligibleIntentIds.contains(intentId)) {
                 continue;
             }
             eligibleById.putIfAbsent(intentId, intent);
@@ -149,7 +149,7 @@ public class RAGPromptService {
     }
 
     private PromptBuildPlan planKbOnly(PromptContext context) {
-        PromptPlan plan = planPrompt(context.getKbIntents(), context.getRetrievedIntentIds());
+        PromptPlan plan = planPrompt(context.getKbIntents(), context.getEligibleIntentIds());
         return PromptBuildPlan.builder()
                 .scene(PromptScene.KB_ONLY)
                 .baseTemplate(plan.getBaseTemplate())

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/KnowledgeRetrievalResult.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/KnowledgeRetrievalResult.java
@@ -17,8 +17,11 @@
 
 package com.nageoffer.ai.ragent.rag.core.retrieval;
 
+import cn.hutool.core.util.StrUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunkKey;
+import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
+import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,17 +31,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public record KnowledgeRetrievalResult(List<RetrievedChunk> chunks,
-                                       Map<String, Set<String>> intentIdsByChunkKey) {
+                                       Map<String, Set<String>> intentIdsByChunkKey,
+                                       Set<String> directedIntentIds) {
 
     public KnowledgeRetrievalResult {
         chunks = chunks == null ? List.of() : chunks;
         intentIdsByChunkKey = intentIdsByChunkKey == null ? Map.of() : intentIdsByChunkKey;
+        directedIntentIds = directedIntentIds == null
+                ? Set.of()
+                : Set.copyOf(directedIntentIds);
     }
 
     public static KnowledgeRetrievalResult empty() {
-        return new KnowledgeRetrievalResult(List.of(), Map.of());
+        return new KnowledgeRetrievalResult(List.of(), Map.of(), Set.of());
     }
 
     public Set<String> retrievedIntentIds() {
@@ -47,6 +55,19 @@ public record KnowledgeRetrievalResult(List<RetrievedChunk> chunks,
                 .filter(Objects::nonNull)
                 .forEach(intentIds::addAll);
         return Collections.unmodifiableSet(intentIds);
+    }
+
+    public Set<String> eligibleIntentIds(List<NodeScore> candidateIntents) {
+        Set<String> retrievedIntentIds = retrievedIntentIds();
+        return candidateIntents.stream()
+                .filter(Objects::nonNull)
+                .map(NodeScore::getNode)
+                .filter(Objects::nonNull)
+                .map(IntentNode::getId)
+                .filter(StrUtil::isNotBlank)
+                .filter(intentId -> !directedIntentIds.contains(intentId)
+                        || retrievedIntentIds.contains(intentId))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public Map<String, List<RetrievedChunk>> groupByIntent(String globalKey) {

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
@@ -87,7 +87,10 @@ public class MultiChannelRetrievalEngine {
         }
 
         List<RetrievedChunk> chunks = executePostProcessors(channelResults, context);
-        return new KnowledgeRetrievalResult(chunks, deriveAttribution(chunks, context.getRetrievalScope()));
+        return new KnowledgeRetrievalResult(
+                chunks,
+                deriveAttribution(chunks, context.getRetrievalScope()),
+                context.getRetrievalScope().directedIntentIds());
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngine.java
@@ -87,6 +87,7 @@ public class MultiChannelRetrievalEngine {
         }
 
         List<RetrievedChunk> chunks = executePostProcessors(channelResults, context);
+        // 异常或超时导致定向证据为空时，保留的定向范围会使其按未命中处理
         return new KnowledgeRetrievalResult(
                 chunks,
                 deriveAttribution(chunks, context.getRetrievalScope()),

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
@@ -44,10 +44,12 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -99,7 +101,10 @@ public class RetrievalEngine {
                                 return buildSubQuestionContext(si, budget);
                             } catch (Exception e) {
                                 log.error("子问题上下文构建失败，降级为空上下文，question：{}", si.subQuestion(), e);
-                                return new SubQuestionContext(si.subQuestion(), "", "", Map.of());
+                                return new SubQuestionContext(
+                                        si.subQuestion(), "", "", Map.of(),
+                                        KnowledgeRetrievalResult.empty().eligibleIntentIds(
+                                                NodeScoreFilters.kb(si.nodeScores())));
                             }
                         },
                         ragContextExecutor
@@ -110,7 +115,9 @@ public class RetrievalEngine {
                 .toList();
 
         Map<String, List<RetrievedChunk>> mergedIntentChunks = new LinkedHashMap<>();
+        Set<String> eligibleIntentIds = new LinkedHashSet<>();
         for (SubQuestionContext context : contexts) {
+            eligibleIntentIds.addAll(context.eligibleIntentIds());
             if (CollUtil.isNotEmpty(context.intentChunks())) {
                 context.intentChunks().forEach((intentId, chunks) -> {
                     if (CollUtil.isEmpty(chunks)) {
@@ -156,6 +163,7 @@ public class RetrievalEngine {
                 .mcpContext(mcpContext)
                 .kbContext(kbContext)
                 .intentChunks(mergedIntentChunks)
+                .eligibleIntentIds(Set.copyOf(eligibleIntentIds))
                 .build();
     }
 
@@ -169,7 +177,8 @@ public class RetrievalEngine {
                 ? executeMcpAndMerge(intent.subQuestion(), mcpIntents)
                 : "";
 
-        return new SubQuestionContext(intent.subQuestion(), kbResult.groupedContext(), mcpContext, kbResult.intentChunks());
+        return new SubQuestionContext(intent.subQuestion(), kbResult.groupedContext(), mcpContext,
+                kbResult.intentChunks(), kbResult.eligibleIntentIds());
     }
 
     private void appendSection(StringBuilder builder, String section, int index, String question, String context) {
@@ -201,16 +210,17 @@ public class RetrievalEngine {
         KnowledgeRetrievalResult retrievalResult =
                 multiChannelRetrievalEngine.retrieveKnowledgeChannels(intent, budget);
         List<RetrievedChunk> chunks = retrievalResult.chunks();
+        Set<String> eligibleIntentIds = retrievalResult.eligibleIntentIds(kbIntents);
 
         if (CollUtil.isEmpty(chunks)) {
-            return KbResult.empty();
+            return new KbResult("", Map.of(), eligibleIntentIds);
         }
 
         Map<String, List<RetrievedChunk>> intentChunks = retrievalResult.groupByIntent(MULTI_CHANNEL_KEY);
 
         String groupedContext = contextFormatter.formatKbContext(
-                kbIntents, retrievalResult.retrievedIntentIds(), chunks, budget.contextTopK());
-        return new KbResult(groupedContext, intentChunks);
+                kbIntents, eligibleIntentIds, chunks, budget.contextTopK());
+        return new KbResult(groupedContext, intentChunks, eligibleIntentIds);
     }
 
     /**
@@ -306,6 +316,7 @@ public class RetrievalEngine {
     private record SubQuestionContext(String question,
                                       String kbContext,
                                       String mcpContext,
-                                      Map<String, List<RetrievedChunk>> intentChunks) {
+                                      Map<String, List<RetrievedChunk>> intentChunks,
+                                      Set<String> eligibleIntentIds) {
     }
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/RetrievalScope.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/RetrievalScope.java
@@ -19,7 +19,9 @@ package com.nageoffer.ai.ragent.rag.core.retrieval.channel;
 
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 检索作用域
@@ -38,6 +40,24 @@ public record RetrievalScope(boolean directed,
                              List<NodeScore> intents,
                              List<String> targetCollections,
                              List<String> supplementCollections) {
+
+    public Set<String> directedIntentIds() {
+        if (!directed) {
+            return Set.of();
+        }
+        Set<String> intentIds = new LinkedHashSet<>();
+        for (NodeScore intent : intents) {
+            if (intent == null || intent.getNode() == null) {
+                continue;
+            }
+            String intentId = intent.getNode().getId();
+            if (intentId == null || intentId.isBlank()) {
+                continue;
+            }
+            intentIds.add(intentId);
+        }
+        return Set.copyOf(intentIds);
+    }
 
     /**
      * 全局作用域：不收窄，无补充路

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/KbResult.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/KbResult.java
@@ -21,18 +21,16 @@ import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * KB 检索结果
  *
  * @param groupedContext 分组后的上下文文本
  * @param intentChunks   意图 ID -> 分片列表
+ * @param eligibleIntentIds 允许参与模板选择和规则注入的意图 ID
  */
-public record KbResult(String groupedContext, Map<String, List<RetrievedChunk>> intentChunks) {
-    /**
-     * 空结果
-     */
-    public static KbResult empty() {
-        return new KbResult("", Map.of());
-    }
+public record KbResult(String groupedContext,
+                       Map<String, List<RetrievedChunk>> intentChunks,
+                       Set<String> eligibleIntentIds) {
 }

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
@@ -52,6 +52,12 @@ public class RetrievalContext {
     private Map<String, List<RetrievedChunk>> intentChunks;
 
     /**
+     * 允许参与模板选择和规则注入的意图 ID
+     */
+    @Builder.Default
+    private Set<String> eligibleIntentIds = Set.of();
+
+    /**
      * 是否存在 MCP 上下文
      */
     public boolean hasMcp() {

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/dto/RetrievalContext.java
@@ -25,9 +25,6 @@ import lombok.Data;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.MULTI_CHANNEL_KEY;
 
 /**
  * 检索上下文（MCP + KB 结果的统一承载）
@@ -69,15 +66,6 @@ public class RetrievalContext {
      */
     public boolean hasKb() {
         return StrUtil.isNotBlank(kbContext);
-    }
-
-    public Set<String> getRetrievedIntentIds() {
-        if (intentChunks == null || intentChunks.isEmpty()) {
-            return Set.of();
-        }
-        return intentChunks.keySet().stream()
-                .filter(intentId -> !MULTI_CHANNEL_KEY.equals(intentId))
-                .collect(Collectors.toUnmodifiableSet());
     }
 
     /**

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipeline.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipeline.java
@@ -226,7 +226,7 @@ public class StreamChatPipeline {
                 .kbContext(ctx.getKbContext())
                 .mcpIntents(intentGroup.mcpIntents())
                 .kbIntents(intentGroup.kbIntents())
-                .retrievedIntentIds(ctx.getRetrievedIntentIds())
+                .eligibleIntentIds(ctx.getEligibleIntentIds())
                 .build();
 
         List<ChatMessage> messages = promptBuilder.buildStructuredMessages(

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatterTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/DefaultContextFormatterTest.java
@@ -113,7 +113,7 @@ class DefaultContextFormatterTest {
     }
 
     @Test
-    void onlyRetrievedIntentContributesSnippet() {
+    void onlyEligibleIntentContributesSnippet() {
         NodeScore intentA = intent("A", "SNIPPET_A");
         NodeScore intentB = intent("B", "SNIPPET_B");
         RetrievedChunk chunkA = chunk("chunk-a", "A的资料", "docA", null, 0, 0.9f);
@@ -126,23 +126,39 @@ class DefaultContextFormatterTest {
         );
 
         assertTrue(result.contains("SNIPPET_A"));
-        assertFalse(result.contains("SNIPPET_B"), "未召回 Chunk 的候选意图不得注入 snippet");
+        assertFalse(result.contains("SNIPPET_B"), "未进入提示词规划的意图不应注入回答规则");
         assertTrue(result.contains("A的资料"));
     }
 
     @Test
-    void globalEvidenceDoesNotActivateCandidateSnippet() {
+    void directedMissKeepsEvidenceWithoutCandidateSnippet() {
+        NodeScore intentA = intent("A", "SNIPPET_A");
+        RetrievedChunk supplement = chunk("supplement", "补充资料", null, null, 0, 0.9f);
+
+        String result = formatter().formatKbContext(
+                List.of(intentA),
+                Set.of(),
+                List.of(supplement),
+                100
+        );
+
+        assertFalse(result.contains("SNIPPET_A"));
+        assertTrue(result.contains("补充资料"));
+    }
+
+    @Test
+    void globalEvidenceKeepsUnevaluatedCandidateSnippet() {
         NodeScore intentA = intent("A", "SNIPPET_A");
         RetrievedChunk globalChunk = chunk("global", "全局资料", null, null, 0, 0.9f);
 
         String result = formatter().formatKbContext(
                 List.of(intentA),
-                Set.of(),
+                Set.of("A"),
                 List.of(globalChunk),
                 100
         );
 
-        assertFalse(result.contains("SNIPPET_A"));
+        assertTrue(result.contains("SNIPPET_A"));
         assertTrue(result.contains("全局资料"));
     }
 

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
@@ -178,24 +178,9 @@ class RAGPromptServiceTest {
     }
 
     @Test
-    void usesTemplateForDuplicateExactIntentCandidates() {
+    void usesTemplateWhenDuplicateCandidatesShareEligibleId() {
         PromptContext context = PromptContext.builder()
                 .kbContext("<content>意图资料</content>")
-                .kbIntents(List.of(
-                        intentWithTemplate("intent-1", "# 单意图模板"),
-                        intentWithTemplate("intent-1", "# 单意图模板")))
-                .eligibleIntentIds(Set.of("intent-1"))
-                .build();
-
-        String result = service(false).buildSystemPrompt(context);
-
-        assertTrue(result.startsWith("# 单意图模板"));
-    }
-
-    @Test
-    void usesTemplateForDuplicateGlobalIntentCandidates() {
-        PromptContext context = PromptContext.builder()
-                .kbContext("<content>全局资料</content>")
                 .kbIntents(List.of(
                         intentWithTemplate("intent-1", "# 单意图模板"),
                         intentWithTemplate("intent-1", "# 单意图模板")))

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/prompt/RAGPromptServiceTest.java
@@ -54,7 +54,7 @@ class RAGPromptServiceTest {
         return PromptContext.builder()
                 .kbContext("<content ref=\"1\">资料</content>")
                 .kbIntents(List.of())
-                .retrievedIntentIds(Set.of())
+                .eligibleIntentIds(Set.of())
                 .build();
     }
 
@@ -105,7 +105,7 @@ class RAGPromptServiceTest {
         PromptContext context = PromptContext.builder()
                 .kbContext("<content>资料</content>")
                 .kbIntents(List.of(intentWithTemplate("# 自定义意图模板")))
-                .retrievedIntentIds(Set.of("intent-1"))
+                .eligibleIntentIds(Set.of("intent-1"))
                 .build();
 
         String result = service(true).buildSystemPrompt(context);
@@ -121,7 +121,7 @@ class RAGPromptServiceTest {
         PromptContext context = PromptContext.builder()
                 .kbContext("<content>全局资料</content>")
                 .kbIntents(List.of(intentWithTemplate("intent-1", "# 单意图模板")))
-                .retrievedIntentIds(Set.of())
+                .eligibleIntentIds(Set.of("intent-1"))
                 .build();
 
         String result = service(false).buildSystemPrompt(context);
@@ -131,13 +131,27 @@ class RAGPromptServiceTest {
     }
 
     @Test
-    void usesExactRetrievedIntentTemplateAmongCandidates() {
+    void directedMissUsesDefaultTemplate() {
+        PromptContext context = PromptContext.builder()
+                .kbContext("<content>补充资料</content>")
+                .kbIntents(List.of(intentWithTemplate("intent-1", "# 未命中模板")))
+                .eligibleIntentIds(Set.of())
+                .build();
+
+        String result = service(false).buildSystemPrompt(context);
+
+        assertTrue(result.startsWith(STUB_BASE_TEMPLATE));
+        assertFalse(result.contains("# 未命中模板"));
+    }
+
+    @Test
+    void usesOnlyEligibleIntentTemplateAmongCandidates() {
         PromptContext context = PromptContext.builder()
                 .kbContext("<content>意图资料</content>")
                 .kbIntents(List.of(
                         intentWithTemplate("intent-1", "# 未命中模板"),
                         intentWithTemplate("intent-2", "# 命中模板")))
-                .retrievedIntentIds(Set.of("intent-2"))
+                .eligibleIntentIds(Set.of("intent-2"))
                 .build();
 
         String result = service(false).buildSystemPrompt(context);
@@ -153,7 +167,7 @@ class RAGPromptServiceTest {
                 .kbIntents(List.of(
                         intentWithTemplate("intent-1", "# 候选模板一"),
                         intentWithTemplate("intent-2", "# 候选模板二")))
-                .retrievedIntentIds(Set.of())
+                .eligibleIntentIds(Set.of("intent-1", "intent-2"))
                 .build();
 
         String result = service(false).buildSystemPrompt(context);
@@ -170,7 +184,7 @@ class RAGPromptServiceTest {
                 .kbIntents(List.of(
                         intentWithTemplate("intent-1", "# 单意图模板"),
                         intentWithTemplate("intent-1", "# 单意图模板")))
-                .retrievedIntentIds(Set.of("intent-1"))
+                .eligibleIntentIds(Set.of("intent-1"))
                 .build();
 
         String result = service(false).buildSystemPrompt(context);
@@ -185,7 +199,7 @@ class RAGPromptServiceTest {
                 .kbIntents(List.of(
                         intentWithTemplate("intent-1", "# 单意图模板"),
                         intentWithTemplate("intent-1", "# 单意图模板")))
-                .retrievedIntentIds(Set.of())
+                .eligibleIntentIds(Set.of("intent-1"))
                 .build();
 
         String result = service(false).buildSystemPrompt(context);
@@ -200,7 +214,7 @@ class RAGPromptServiceTest {
                 .kbContext("<content ref=\"1\">资料</content>")
                 .mcpIntents(List.of())
                 .kbIntents(List.of())
-                .retrievedIntentIds(Set.of())
+                .eligibleIntentIds(Set.of())
                 .build();
 
         String result = service(true).buildSystemPrompt(context);

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
@@ -116,9 +116,9 @@ class MultiChannelRetrievalEngineTest {
     }
 
     @Test
-    void slowChannelDegradesToEmptyAfterChannelTimeout() {
+    void directedTimeoutKeepsScopeAndDegradesToMiss() {
         // 慢通道模拟卡死的后端：超时只丢它自己的结果，不钳制同一子问题里其余通道
-        RetrievedChunk fastChunk = chunk("fast", "快通道资料", 0.9F);
+        RetrievedChunk fastChunk = chunk("fast", "补充库资料", "kb-supplement", 0.9F);
         SearchChannel fast = channel(
                 "vector",
                 SearchChannelType.VECTOR,
@@ -144,7 +144,9 @@ class MultiChannelRetrievalEngineTest {
         SearchChannelProperties properties = new SearchChannelProperties();
         properties.getChannels().setTimeoutMs(200);
         RetrievalScopeResolver resolver = mock(RetrievalScopeResolver.class);
-        when(resolver.resolve(anyList())).thenReturn(RetrievalScope.global(0.0, List.of("kb-a")));
+        NodeScore candidate = intent("A", "kb-a");
+        when(resolver.resolve(anyList())).thenReturn(directedScope(
+                List.of(candidate), List.of("kb-a"), List.of("kb-supplement")));
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
@@ -163,6 +165,9 @@ class MultiChannelRetrievalEngineTest {
 
             assertEquals(List.of("fast"), result.chunks().stream().map(RetrievedChunk::getId).toList(),
                     "慢通道超时按空结果降级，快通道证据保留");
+            assertEquals(Set.of("A"), result.directedIntentIds());
+            assertTrue(result.retrievedIntentIds().isEmpty());
+            assertTrue(result.eligibleIntentIds(List.of(candidate)).isEmpty());
             assertTrue(elapsedMs < 800, "慢通道不得钳制整次检索，实际耗时 " + elapsedMs + "ms");
         } finally {
             pool.shutdownNow();

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/MultiChannelRetrievalEngineTest.java
@@ -79,6 +79,7 @@ class MultiChannelRetrievalEngineTest {
         assertEquals(List.of(keywordChunk), grouped.get("B"), "关键词证据按库获得归属");
         assertEquals(List.of(supplementChunk), grouped.get("multi_channel"));
         assertEquals(Set.of("A", "B"), result.retrievedIntentIds());
+        assertEquals(Set.of("A", "B"), result.directedIntentIds());
         assertFalse(result.intentIdsByChunkKey().containsKey(RetrievedChunkKey.of(discarded)));
     }
 
@@ -96,6 +97,7 @@ class MultiChannelRetrievalEngineTest {
 
         assertEquals(Set.of("报销", "发票"),
                 result.intentIdsByChunkKey().get(RetrievedChunkKey.of(sharedChunk)));
+        assertEquals(Set.of("报销", "发票"), result.directedIntentIds());
     }
 
     @Test
@@ -109,6 +111,7 @@ class MultiChannelRetrievalEngineTest {
                 .retrieveKnowledgeChannels(new SubQuestionIntent("问题", List.of()), RetrievalBudget.uniform(10));
 
         assertTrue(result.intentIdsByChunkKey().isEmpty());
+        assertTrue(result.directedIntentIds().isEmpty());
         assertEquals(List.of(globalChunk), result.groupByIntent("multi_channel").get("multi_channel"));
     }
 
@@ -140,6 +143,8 @@ class MultiChannelRetrievalEngineTest {
 
         SearchChannelProperties properties = new SearchChannelProperties();
         properties.getChannels().setTimeoutMs(200);
+        RetrievalScopeResolver resolver = mock(RetrievalScopeResolver.class);
+        when(resolver.resolve(anyList())).thenReturn(RetrievalScope.global(0.0, List.of("kb-a")));
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
@@ -147,7 +152,7 @@ class MultiChannelRetrievalEngineTest {
             KnowledgeRetrievalResult result = new MultiChannelRetrievalEngine(
                     List.of(fast, slow),
                     List.of(),
-                    mock(RetrievalScopeResolver.class),
+                    resolver,
                     pool,
                     properties)
                     .retrieveKnowledgeChannels(

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.MULTI_CHANNEL_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -56,7 +57,8 @@ class RetrievalEngineTest {
                 any(SubQuestionIntent.class), any(RetrievalBudget.class)))
                 .thenReturn(new KnowledgeRetrievalResult(
                         List.of(chunkA, globalChunk),
-                        Map.of(RetrievedChunkKey.of(chunkA), Set.of("A"))
+                        Map.of(RetrievedChunkKey.of(chunkA), Set.of("A")),
+                        Set.of("A", "B")
                 ));
 
         RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
@@ -68,7 +70,92 @@ class RetrievalEngineTest {
                 MULTI_CHANNEL_KEY, List.of(globalChunk)
         ), result.getIntentChunks());
         assertEquals(Set.of("A"), result.getRetrievedIntentIds());
+        assertEquals(Set.of("A"), result.getEligibleIntentIds());
         verify(contextFormatter).formatKbContext(anyList(), eq(Set.of("A")), eq(List.of(chunkA, globalChunk)), anyInt());
+    }
+
+    @Test
+    void globalEvidenceKeepsCandidatesEligible() {
+        RetrievedChunk globalChunk = chunk("global", "全局资料");
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        ContextFormatter contextFormatter = mock(ContextFormatter.class);
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenReturn(new KnowledgeRetrievalResult(List.of(globalChunk), Map.of(), Set.of()));
+
+        RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题", List.of(intent("A"), intent("B")))
+        ));
+
+        assertEquals(Set.of("A", "B"), result.getEligibleIntentIds());
+        verify(contextFormatter).formatKbContext(
+                anyList(), eq(Set.of("A", "B")), eq(List.of(globalChunk)), anyInt());
+    }
+
+    @Test
+    void directedMissKeepsEvidenceWithoutEligibleIntent() {
+        RetrievedChunk supplement = chunk("supplement", "补充资料");
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        ContextFormatter contextFormatter = mock(ContextFormatter.class);
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenReturn(new KnowledgeRetrievalResult(List.of(supplement), Map.of(), Set.of("A")));
+        when(contextFormatter.formatKbContext(anyList(), any(), anyList(), anyInt()))
+                .thenReturn("补充资料上下文");
+
+        RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题", List.of(intent("A")))
+        ));
+
+        assertTrue(result.getEligibleIntentIds().isEmpty());
+        assertEquals("补充资料上下文", result.getKbContext());
+        assertEquals(List.of(supplement), result.getIntentChunks().get(MULTI_CHANNEL_KEY));
+        verify(contextFormatter).formatKbContext(anyList(), eq(Set.of()), eq(List.of(supplement)), anyInt());
+    }
+
+    @Test
+    void multiQuestionEligibilityUsesEachQuestionOutcome() {
+        RetrievedChunk hitChunk = chunk("hit", "A资料");
+        KnowledgeRetrievalResult unknown = KnowledgeRetrievalResult.empty();
+        KnowledgeRetrievalResult hit = new KnowledgeRetrievalResult(
+                List.of(hitChunk), Map.of(RetrievedChunkKey.of(hitChunk), Set.of("A")), Set.of("A"));
+        KnowledgeRetrievalResult miss = new KnowledgeRetrievalResult(List.of(), Map.of(), Set.of("A"));
+
+        assertEquals(Set.of("A"), eligibleAfterTwoQuestions(unknown, miss));
+        assertEquals(Set.of("A"), eligibleAfterTwoQuestions(hit, miss));
+        assertTrue(eligibleAfterTwoQuestions(miss, miss).isEmpty());
+    }
+
+    @Test
+    void failedSubQuestionKeepsCandidateUnevaluated() {
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        ContextFormatter contextFormatter = mock(ContextFormatter.class);
+        KnowledgeRetrievalResult miss = new KnowledgeRetrievalResult(List.of(), Map.of(), Set.of("A"));
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenThrow(new IllegalStateException("retrieval unavailable"))
+                .thenReturn(miss);
+
+        RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题一", List.of(intent("A"))),
+                new SubQuestionIntent("问题二", List.of(intent("A")))
+        ));
+
+        assertEquals(Set.of("A"), result.getEligibleIntentIds());
+    }
+
+    private Set<String> eligibleAfterTwoQuestions(KnowledgeRetrievalResult first,
+                                                   KnowledgeRetrievalResult second) {
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        ContextFormatter contextFormatter = mock(ContextFormatter.class);
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenReturn(first, second);
+
+        return engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题一", List.of(intent("A"))),
+                new SubQuestionIntent("问题二", List.of(intent("A")))
+        )).getEligibleIntentIds();
     }
 
     private RetrievalEngine engine(MultiChannelRetrievalEngine multiChannel, ContextFormatter contextFormatter) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngineTest.java
@@ -25,10 +25,12 @@ import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
 import com.nageoffer.ai.ragent.rag.core.mcp.McpParameterExtractor;
 import com.nageoffer.ai.ragent.rag.core.mcp.McpToolRegistry;
 import com.nageoffer.ai.ragent.rag.core.prompt.ContextFormatter;
+import com.nageoffer.ai.ragent.rag.core.prompt.DefaultContextFormatter;
 import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
 import com.nageoffer.ai.ragent.rag.dto.RetrievalContext;
 import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +71,6 @@ class RetrievalEngineTest {
                 "A", List.of(chunkA),
                 MULTI_CHANNEL_KEY, List.of(globalChunk)
         ), result.getIntentChunks());
-        assertEquals(Set.of("A"), result.getRetrievedIntentIds());
         assertEquals(Set.of("A"), result.getEligibleIntentIds());
         verify(contextFormatter).formatKbContext(anyList(), eq(Set.of("A")), eq(List.of(chunkA, globalChunk)), anyInt());
     }
@@ -90,6 +91,28 @@ class RetrievalEngineTest {
         assertEquals(Set.of("A", "B"), result.getEligibleIntentIds());
         verify(contextFormatter).formatKbContext(
                 anyList(), eq(Set.of("A", "B")), eq(List.of(globalChunk)), anyInt());
+    }
+
+    @Test
+    void globalFallbackInjectsBothLowConfidenceCandidateSnippets() {
+        RetrievedChunk globalChunk = chunk("global", "全局资料");
+        MultiChannelRetrievalEngine multiChannel = mock(MultiChannelRetrievalEngine.class);
+        when(multiChannel.retrieveKnowledgeChannels(
+                any(SubQuestionIntent.class), any(RetrievalBudget.class)))
+                .thenReturn(new KnowledgeRetrievalResult(List.of(globalChunk), Map.of(), Set.of()));
+        ContextFormatter contextFormatter = new DefaultContextFormatter(
+                new PromptTemplateLoader(new DefaultResourceLoader()));
+
+        RetrievalContext result = engine(multiChannel, contextFormatter).retrieve(List.of(
+                new SubQuestionIntent("问题", List.of(
+                        lowConfidenceIntentWithSnippet("A", "SNIPPET_A"),
+                        lowConfidenceIntentWithSnippet("B", "SNIPPET_B")))
+        ));
+
+        assertEquals(Set.of("A", "B"), result.getEligibleIntentIds());
+        assertTrue(result.getKbContext().contains("SNIPPET_A"));
+        assertTrue(result.getKbContext().contains("SNIPPET_B"));
+        assertTrue(result.getKbContext().contains("全局资料"));
     }
 
     @Test
@@ -173,6 +196,13 @@ class RetrievalEngineTest {
 
     private NodeScore intent(String id) {
         return NodeScore.builder().node(IntentNode.builder().id(id).build()).score(0.9).build();
+    }
+
+    private NodeScore lowConfidenceIntentWithSnippet(String id, String snippet) {
+        return NodeScore.builder()
+                .node(IntentNode.builder().id(id).promptSnippet(snippet).build())
+                .score(0.5)
+                .build();
     }
 
     private RetrievedChunk chunk(String id, String text) {

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/RetrievalScopeResolverTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/core/retrieval/channel/RetrievalScopeResolverTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,6 +44,7 @@ class RetrievalScopeResolverTest {
         RetrievalScope scope = resolve(intent("kb-finance", 0.9));
 
         assertTrue(scope.directed());
+        assertEquals(Set.of("intent-kb-finance"), scope.directedIntentIds());
         assertEquals(List.of("kb-finance"), scope.targetCollections());
         assertEquals(List.of("kb-hr", "kb-tech"), scope.supplementCollections());
     }
@@ -53,6 +55,7 @@ class RetrievalScopeResolverTest {
         RetrievalScope scope = resolve(intent("kb-finance", 0.5));
 
         assertFalse(scope.directed());
+        assertTrue(scope.directedIntentIds().isEmpty());
         assertEquals(ACTIVE, scope.targetCollections());
         assertTrue(scope.supplementCollections().isEmpty());
     }

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipelineTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/pipeline/StreamChatPipelineTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.pipeline;
+
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.infra.chat.StreamCallback;
+import com.nageoffer.ai.ragent.rag.core.guidance.GuidanceDecision;
+import com.nageoffer.ai.ragent.rag.core.guidance.IntentGuidanceService;
+import com.nageoffer.ai.ragent.rag.core.intent.IntentResolver;
+import com.nageoffer.ai.ragent.rag.core.memory.ConversationMemoryService;
+import com.nageoffer.ai.ragent.rag.core.prompt.AgentPromptResolver;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptContext;
+import com.nageoffer.ai.ragent.rag.core.prompt.RAGPromptService;
+import com.nageoffer.ai.ragent.rag.core.retrieval.RetrievalEngine;
+import com.nageoffer.ai.ragent.rag.core.rewrite.QueryRewriteService;
+import com.nageoffer.ai.ragent.rag.core.rewrite.RewriteResult;
+import com.nageoffer.ai.ragent.rag.core.source.CitationContextEnricher;
+import com.nageoffer.ai.ragent.rag.core.source.GroundingChunksAssembler;
+import com.nageoffer.ai.ragent.rag.core.source.SourcesAssembler;
+import com.nageoffer.ai.ragent.rag.dto.IntentGroup;
+import com.nageoffer.ai.ragent.rag.dto.RetrievalContext;
+import com.nageoffer.ai.ragent.rag.dto.SubQuestionIntent;
+import com.nageoffer.ai.ragent.rag.service.handler.StreamTaskManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreamChatPipelineTest {
+
+    @Mock
+    private ConversationMemoryService memoryService;
+    @Mock
+    private QueryRewriteService queryRewriteService;
+    @Mock
+    private IntentResolver intentResolver;
+    @Mock
+    private IntentGuidanceService guidanceService;
+    @Mock
+    private RetrievalEngine retrievalEngine;
+    @Mock
+    private LLMService llmService;
+    @Mock
+    private RAGPromptService promptBuilder;
+    @Mock
+    private AgentPromptResolver agentPromptResolver;
+    @Mock
+    private StreamTaskManager taskManager;
+    @Mock
+    private SourcesAssembler sourcesAssembler;
+    @Mock
+    private GroundingChunksAssembler groundingChunksAssembler;
+    @Mock
+    private CitationContextEnricher citationContextEnricher;
+
+    @InjectMocks
+    private StreamChatPipeline pipeline;
+
+    @Test
+    void passesEligibleIntentIdsToPromptContext() {
+        StreamCallback callback = org.mockito.Mockito.mock(StreamCallback.class);
+        RewriteResult rewriteResult = new RewriteResult("改写问题", List.of("改写问题"));
+        List<SubQuestionIntent> subIntents = List.of(new SubQuestionIntent("改写问题", List.of()));
+        Set<String> eligibleIntentIds = Set.of("intent-1");
+        RetrievalContext retrievalContext = RetrievalContext.builder()
+                .kbContext("<content>资料</content>")
+                .intentChunks(Map.of())
+                .eligibleIntentIds(eligibleIntentIds)
+                .build();
+
+        when(memoryService.load("conversation-1", "user-1")).thenReturn(List.of());
+        when(memoryService.append(any(), any(), any())).thenReturn("message-1");
+        when(queryRewriteService.rewriteWithSplit("原问题", List.of())).thenReturn(rewriteResult);
+        when(intentResolver.resolve(rewriteResult)).thenReturn(subIntents);
+        when(guidanceService.detectAmbiguity("改写问题", subIntents)).thenReturn(GuidanceDecision.none());
+        when(intentResolver.isSystemOnly(anyList())).thenReturn(false);
+        when(retrievalEngine.retrieve(subIntents)).thenReturn(retrievalContext);
+        when(intentResolver.mergeIntentGroup(subIntents)).thenReturn(new IntentGroup(List.of(), List.of()));
+        when(citationContextEnricher.enrich("<content>资料</content>", List.of()))
+                .thenReturn("<content>资料</content>");
+        when(promptBuilder.buildStructuredMessages(any(), anyList(), any(), anyList())).thenReturn(List.of());
+
+        pipeline.execute(StreamChatContext.builder()
+                .question("原问题")
+                .conversationId("conversation-1")
+                .taskId("task-1")
+                .userId("user-1")
+                .callback(callback)
+                .build());
+
+        ArgumentCaptor<PromptContext> promptContext = ArgumentCaptor.forClass(PromptContext.class);
+        verify(promptBuilder).buildStructuredMessages(promptContext.capture(), anyList(), any(), anyList());
+        assertEquals(eligibleIntentIds, promptContext.getValue().getEligibleIntentIds());
+    }
+}


### PR DESCRIPTION
## 说明

#105 的问题 B 中，`retrievedIntentIds` 为空包含两种不同情况：定向检索已经执行但没有命中，或者低置信度候选回退到全局检索，根本没有按意图查询。

原实现没有区分这两种情况。全局回退时，候选意图会被当作未命中过滤，相关 `promptSnippet` 和 `promptTemplate` 也无法参与 Prompt 规划。

## 改动

- 检索结果同时保留最终 Chunk 归属和实际执行过定向检索的意图 ID
- 根据定向检索范围和最终命中结果计算 `eligibleIntentIds`
- 只在定向检索实际执行且没有存活证据时排除候选；全局回退时继续保留候选
- Formatter 和 Prompt 规划统一使用 `eligibleIntentIds` 选择 snippet 与模板
- 全局回退存在多个低置信度候选时，按已确认的行为注入每个候选的 snippet
- 删除不再使用的 `RetrievalContext.getRetrievedIntentIds()`，日志继续使用 `检索归因 - 提示词分支` 前缀
- 补充定向命中、定向未命中、全局回退、多候选、多子问题、置信度边界和流水线字段传播测试

## 验证

- 本 PR 相关测试：90 tests，0 failures，0 errors，0 skipped
- `mvn.cmd -pl bootstrap -am spotless:check`：BUILD SUCCESS
- `git diff --check`：passed

## 边界和范围

检索通道发生异常或超时时，当前仍会降级为空结果。如果定向证据因此为空，下游会按定向未命中处理。本 PR 记录这一现有行为，不扩展新的检索状态。

问题 A 已由上游提交 [`cf2697c0`](https://github.com/nageoffer/ragent/commit/cf2697c091a19a5c0fe23f0f5e1978c7688c8300) 解决：Keyword 和 Graph 返回的 Chunk 已携带 `collectionName`，并由 `MultiChannelRetrievalEngine` 统一推导意图归属。本 PR 仅核查并沿用该实现，不再修改检索通道。
