### PR TITLE
fix(vite): bind dev server to IPv4 loopback

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
         }
     },
     server: {
+        host: "127.0.0.1",
         port: 5173,
         proxy: {
             "/api": {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     }
   },
   server: {
+    host: "127.0.0.1",
     port: 5173,
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary

- Fixes #7 by explicitly binding the Vite development server to the IPv4 loopback address.
- Keep the generated JavaScript config aligned with the TypeScript source config.

## Validation

- npm run build: passed
- Started the default Vite dev server without CLI host overrides
- Connected successfully to 127.0.0.1:5173
- git diff --check: passed

## Scope

This only affects local development-server binding. The API proxy and port remain unchanged.