### PR TITLE
feat(security): 添加输入输出安全过滤模块

### DIFF
--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/DefaultSafetyFilter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/DefaultSafetyFilter.java
@@ -1,0 +1,143 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import cn.hutool.core.collection.CollUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 瀹夊叏杩囨护鍣ㄩ粯璁ゅ疄鐜?
+ * <p>
+ * 閫氳繃鏋勯€犲嚱鏁版敞鍏?{@code List<SafetyRule>} 鈥斺€?Spring 鑷姩鏀堕泦鎵€鏈?
+ * 瀹炵幇浜?{@link SafetyRule} 鎺ュ彛鐨?Bean锛屾棤闇€鎵嬪姩娉ㄥ唽銆?
+ * 鍙傝€冿細{@code DefaultMcpToolRegistry} 鐨勮嚜鍔ㄥ彂鐜版ā寮忋€?
+ * <p>
+ * 瑙勫垯鎸?{@code @Order} 娉ㄨВ鐨勫€间粠灏忓埌澶т緷娆℃墽琛岋紝閬囧埌棣栦釜 BLOCK 鍗崇煭璺繑鍥炪€?
+ * 鎵€鏈?WARN 缁撴灉浼氳鏀堕泦锛屾渶缁堝悎骞跺埌娑堟伅鍒楄〃涓€?
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DefaultSafetyFilter implements SafetyFilter {
+
+    private final List<SafetyRule> rules;
+    private final SecurityProperties properties;
+    private final SafetyAuditLogger auditLogger;
+
+    @Override
+    public SafetyResult check(SafetyCheckContext context) {
+        // 鎬诲紑鍏冲叧闂?鈫?鍏ㄩ儴鏀捐
+        if (!properties.isEnabled()) {
+            return SafetyResult.pass();
+        }
+
+        if (CollUtil.isEmpty(rules)) {
+            log.debug("瀹夊叏瑙勫垯鍒楄〃涓虹┖锛岃烦杩囧畨鍏ㄦ鏌?);
+            return SafetyResult.pass();
+        }
+
+        List<SafetyResult> warnings = new ArrayList<>();
+
+        for (SafetyRule rule : rules) {
+            if (!rule.isEnabled()) {
+                continue;
+            }
+
+            SafetyResult result;
+            try {
+                result = rule.evaluate(context.getOriginalQuestion(), context);
+            } catch (Exception e) {
+                log.error("瀹夊叏瑙勫垯 {} 鎵ц寮傚父锛岄檷绾т负 PASS", rule.getId(), e);
+                continue;
+            }
+
+            if (result.isBlocked()) {
+                log.warn("瀹夊叏瑙勫垯闃绘柇: ruleId={}, ruleName={}, type={}, confidence={}",
+                        rule.getId(), rule.getName(), result.getRuleType(), result.getConfidence());
+                auditLogger.log(SafetyAuditEvent.builder()
+                        .ruleId(rule.getId())
+                        .ruleName(rule.getName())
+                        .ruleType(result.getRuleType())
+                        .result(SafetyResult.Type.BLOCK)
+                        .question(truncate(context.getOriginalQuestion()))
+                        .userId(context.getUserId())
+                        .conversationId(context.getConversationId())
+                        .taskId(context.getTaskId())
+                        .message(result.getMessage())
+                        .confidence(result.getConfidence())
+                        .build());
+                return result;
+            }
+
+            if (result.isWarned()) {
+                log.info("瀹夊叏瑙勫垯鍛婅: ruleId={}, ruleName={}, type={}, confidence={}",
+                        rule.getId(), rule.getName(), result.getRuleType(), result.getConfidence());
+                warnings.add(result);
+                auditLogger.log(SafetyAuditEvent.builder()
+                        .ruleId(rule.getId())
+                        .ruleName(rule.getName())
+                        .ruleType(result.getRuleType())
+                        .result(SafetyResult.Type.WARN)
+                        .question(truncate(context.getOriginalQuestion()))
+                        .userId(context.getUserId())
+                        .conversationId(context.getConversationId())
+                        .taskId(context.getTaskId())
+                        .message(result.getMessage())
+                        .confidence(result.getConfidence())
+                        .build());
+            }
+        }
+
+        // 娌℃湁 BLOCK锛屼絾瀛樺湪 WARN 鈫?鍚堝苟杩斿洖棣栦釜 WARN锛堟彁绀烘枃妗堬級
+        if (!warnings.isEmpty()) {
+            return SafetyResult.warn(
+                    warnings.get(0).getRuleId(),
+                    buildMergedWarnMessage(warnings),
+                    warnings.get(0).getRuleType(),
+                    warnings.stream().mapToDouble(SafetyResult::getConfidence).max().orElse(0.5)
+            );
+        }
+
+        return SafetyResult.pass();
+    }
+
+    private String buildMergedWarnMessage(List<SafetyResult> warnings) {
+        if (warnings.size() == 1) {
+            return warnings.get(0).getMessage();
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("[瀹夊叏鎻愮ず] 鎮ㄧ殑鎻愰棶瑙﹀彂浜嗗椤瑰畨鍏ㄧ瓥鐣?(");
+        for (int i = 0; i < warnings.size(); i++) {
+            if (i > 0) sb.append("銆?);
+            sb.append(warnings.get(i).getRuleType().name());
+        }
+        sb.append(")锛屾湰娆″洖绛斿凡鑷姩杩藉姞瀹夊叏绾︽潫銆?);
+        return sb.toString();
+    }
+
+    private String truncate(String text) {
+        if (text == null) return null;
+        return text.length() <= 200 ? text : text.substring(0, 200) + "...";
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/McpPermissionEnforcer.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/McpPermissionEnforcer.java
@@ -1,0 +1,88 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import com.nageoffer.ai.ragent.framework.context.UserContext;
+import com.nageoffer.ai.ragent.framework.exception.ClientException;
+import com.nageoffer.ai.ragent.rag.core.mcp.McpToolExecutor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * MCP 宸ュ叿鏉冮檺鎵ц鍣?
+ * <p>
+ * 鍦?{@code RetrievalEngine.executeSingleMcpTool()} 涓皟鐢紝
+ * 妫€鏌ュ綋鍓嶇敤鎴锋槸鍚﹀叿澶囪皟鐢ㄧ洰鏍囧伐鍏风殑鏉冮檺銆?
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class McpPermissionEnforcer {
+
+    private final SecurityProperties properties;
+
+    private static final String ADMIN_ROLE = "admin";
+
+    /**
+     * 妫€鏌ュ綋鍓嶇敤鎴锋槸鍚︽湁鏉冮檺璋冪敤鎸囧畾宸ュ叿
+     *
+     * @param toolId   宸ュ叿 ID
+     * @param executor 宸ュ叿鎵ц鍣?
+     * @throws ClientException 鏉冮檺涓嶈冻鏃舵姏鍑?
+     */
+    public void checkPermission(String toolId, McpToolExecutor executor) {
+        if (!properties.getMcp().isEnforceRoles()) {
+            return;
+        }
+
+        McpToolPermission perm = executor.getClass().getAnnotation(McpToolPermission.class);
+        if (perm == null) {
+            // 鏈爣璁?= 鏃犵壒娈婃潈闄愯姹?
+            return;
+        }
+
+        String currentRole = UserContext.getRole();
+        if (currentRole == null) {
+            log.warn("MCP 鏉冮檺鎷掔粷: toolId={}, 褰撳墠鐢ㄦ埛鏃犺鑹?, toolId);
+            throw new ClientException("褰撳墠鐢ㄦ埛鏃犺鑹叉潈闄愶紝鏃犳硶璋冪敤宸ュ叿: " + toolId);
+        }
+
+        // 绠＄悊鍛樹紭鍏?
+        if (perm.adminOnly() && !ADMIN_ROLE.equalsIgnoreCase(currentRole)) {
+            log.warn("MCP 鏉冮檺鎷掔粷: toolId={}, 闇€瑕佺鐞嗗憳瑙掕壊, 褰撳墠瑙掕壊={}", toolId, currentRole);
+            throw new ClientException("宸ュ叿 " + toolId + " 浠呴檺绠＄悊鍛樹娇鐢?);
+        }
+
+        // 鎸囧畾瑙掕壊鍖归厤
+        String[] requiredRoles = perm.requiredRoles();
+        if (requiredRoles.length > 0) {
+            Set<String> userRoles = Set.of(currentRole.toLowerCase().split(","));
+            boolean matched = Arrays.stream(requiredRoles)
+                    .anyMatch(r -> userRoles.contains(r.toLowerCase()));
+            if (!matched) {
+                log.warn("MCP 鏉冮檺鎷掔粷: toolId={}, 闇€瑕佽鑹?{}, 褰撳墠瑙掕壊={}", toolId, Arrays.toString(requiredRoles), currentRole);
+                throw new ClientException("宸ュ叿 " + toolId + " 闇€瑕佽鑹? " + String.join(", ", requiredRoles));
+            }
+        }
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/McpToolPermission.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/McpToolPermission.java
@@ -1,0 +1,41 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * MCP 宸ュ叿鏉冮檺娉ㄨВ
+ * <p>
+ * 鏍囪鍦?{@code McpToolExecutor} 瀹炵幇绫讳笂锛屽０鏄庤皟鐢ㄨ宸ュ叿鎵€闇€鐨勮鑹层€?
+ * 鏈爣璁扮殑宸ュ叿瑙嗕负鏃犻渶鐗规畩鏉冮檺锛堟墍鏈夌櫥褰曠敤鎴峰彲璋冪敤锛夈€?
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface McpToolPermission {
+
+    /** 闇€瑕佺殑瑙掕壊鍒楄〃 */
+    String[] requiredRoles() default {};
+
+    /** 鏄惁浠呯鐞嗗憳鍙皟鐢?*/
+    boolean adminOnly() default false;
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputContext.java
@@ -1,0 +1,65 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+/**
+ * 杈撳嚭瀹夊叏杩囨护涓婁笅鏂?鈥斺€?璺?chunk 绱Н妫€娴?
+ */
+public class OutputContext {
+
+    private final StringBuilder buffer = new StringBuilder();
+    private boolean terminated = false;
+    private final String taskId;
+
+    public OutputContext(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public void append(String chunk) {
+        buffer.append(chunk);
+    }
+
+    public String getBuffer() {
+        return buffer.toString();
+    }
+
+    public int getBufferLength() {
+        return buffer.length();
+    }
+
+    /**
+     * 缂撳啿鍖鸿秴杩囦笂闄愭椂鎴柇鍓嶅崐閮ㄥ垎
+     */
+    public void truncateHalf() {
+        int half = buffer.length() / 2;
+        buffer.delete(0, half);
+    }
+
+    public boolean isTerminated() {
+        return terminated;
+    }
+
+    public void markTerminated() {
+        this.terminated = true;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputDesensitizer.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputDesensitizer.java
@@ -1,0 +1,74 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import cn.hutool.core.util.StrUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * 鏁忔劅淇℃伅鑴辨晱宸ュ叿绫?
+ * <p>
+ * 瀵?LLM 杈撳嚭涓殑闅愮鏁版嵁杩涜瀹炴椂閬斀锛?
+ * <ul>
+ *   <li>鎵嬫満鍙凤細138****5678</li>
+ *   <li>韬唤璇侊細320***********1234</li>
+ *   <li>閭锛歶***@domain.com</li>
+ *   <li>API Key锛歴k-****...****</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class OutputDesensitizer {
+
+    /** 鎵嬫満鍙凤細淇濈暀鍓?鍚? */
+    private static final Pattern PHONE_MASK = Pattern.compile("(1[3-9]\\d)(\\d{4})(\\d{4})");
+
+    /** 韬唤璇侊細淇濈暀鍓?鍚? */
+    private static final Pattern ID_CARD_MASK = Pattern.compile("(\\d{3})\\d{11}(\\d{4})");
+
+    /** 閭锛氫繚鐣欓瀛楃鍜屽煙鍚?*/
+    private static final Pattern EMAIL_MASK = Pattern.compile("(\\w)[^@]*(@\\w+\\.\\w+)");
+
+    /** API Key锛氫繚鐣欓灏惧悇4浣?*/
+    private static final Pattern API_KEY_MASK = Pattern.compile("(sk-[a-zA-Z0-9]{4})[a-zA-Z0-9_-]+([a-zA-Z0-9]{4})");
+
+    /**
+     * 瀵规枃鏈腑鐨勬晱鎰熶俊鎭繘琛岃劚鏁?
+     *
+     * @param text 鍘熷鏂囨湰
+     * @return 鑴辨晱鍚庣殑鏂囨湰
+     */
+    public String mask(String text) {
+        if (StrUtil.isBlank(text)) {
+            return text;
+        }
+
+        String result = text;
+        result = PHONE_MASK.matcher(result).replaceAll("$1****$3");
+        result = ID_CARD_MASK.matcher(result).replaceAll("$1***********$2");
+        result = EMAIL_MASK.matcher(result).replaceAll("$1***$2");
+        result = API_KEY_MASK.matcher(result).replaceAll("$1****$2");
+
+        return result;
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputSafetyFilter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/OutputSafetyFilter.java
@@ -1,0 +1,109 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import cn.hutool.core.util.StrUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 杈撳嚭瀹夊叏杩囨护鍣?鈥斺€?瀹炴椂杩囨护 LLM 娴佸紡杈撳嚭
+ * <p>
+ * 鍦?StreamChatEventHandler.onContent() 涓姣忎釜杈撳嚭 chunk 杩涜锛?
+ * <ol>
+ *   <li>鏁忔劅淇℃伅鑴辨晱锛堟墜鏈哄彿/韬唤璇?閭/API Key 閬斀锛?/li>
+ *   <li>Prompt 娉勯湶妫€娴嬶紙璺?chunk 绱Н妫€娴嬶級</li>
+ * </ol>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutputSafetyFilter {
+
+    private final SecurityProperties properties;
+    private final OutputDesensitizer desensitizer;
+
+    /** 妫€娴嬪埌娉勯湶鏃惰拷鍔犵殑缁堟鏍囪 */
+    private static final String LEAKAGE_TERMINATION = "\n\n[绯荤粺鎻愮ず锛氭娴嬪埌寮傚父杈撳嚭锛屽凡缁堟鍝嶅簲銆俔";
+
+    /** 娉勯湶妫€娴嬪叧閿瘝 */
+    private static final String[] PROMPT_LEAKAGE_MARKERS = {
+            "浣犳槸鏀垮姟鏀跨瓥", "浣犳槸浼佷笟鏅鸿兘鏁版嵁鍔╂墜", "浣犵殑鑱岃矗鑼冨洿",
+            "鏈彁绀鸿瘝瑙勫垯", "缁濆绂佹", "system prompt", "<tool-data>",
+            "<documents>", "浼樺厛绾у０鏄?
+    };
+
+    /** 绱妫€娴嬬紦鍐插尯鏈€澶ч暱搴︼紙瓒呰繃鍚庨噸缃紝闃叉鍐呭瓨娉勬紡锛?*/
+    private static final int MAX_BUFFER_LENGTH = 2000;
+
+    /**
+     * 杩囨护鍗曚釜杈撳嚭 chunk
+     *
+     * @param chunk 鍘熷 chunk
+     * @param ctx   杈撳嚭涓婁笅鏂囷紙璺?chunk 绱Н妫€娴嬬敤锛?
+     * @return 杩囨护鍚庣殑 chunk锛屽鏋滄娴嬪埌娉勯湶鍒欏湪鏈熬杩藉姞缁堟鏍囪
+     */
+    public String filter(String chunk, OutputContext ctx) {
+        if (!properties.getOutput().isEnabled()) {
+            return chunk;
+        }
+        if (StrUtil.isBlank(chunk)) {
+            return chunk;
+        }
+
+        String result = chunk;
+
+        // 1. 鑴辨晱澶勭悊
+        if (properties.getOutput().isMaskPhone()
+                || properties.getOutput().isMaskEmail()
+                || properties.getOutput().isMaskIdCard()
+                || properties.getOutput().isMaskApiKey()) {
+            result = desensitizer.mask(chunk);
+        }
+
+        // 2. Prompt 娉勯湶妫€娴嬶紙璺?chunk 绱Н锛?
+        if (properties.getOutput().isDetectPromptLeakage() && !ctx.isTerminated()) {
+            ctx.append(result);
+
+            // 缂撳啿鍖鸿秴杩囦笂闄愭椂鎴柇鍓嶅崐閮ㄥ垎锛屼繚鐣欏悗鍗婇儴鍒嗙户缁娴?
+            if (ctx.getBufferLength() > MAX_BUFFER_LENGTH) {
+                ctx.truncateHalf();
+            }
+
+            if (detectLeakage(ctx.getBuffer())) {
+                log.warn("杈撳嚭瀹夊叏-妫€娴嬪埌 Prompt 娉勯湶, taskId={}", ctx.getTaskId());
+                ctx.markTerminated();
+                return result + LEAKAGE_TERMINATION;
+            }
+        }
+
+        return result;
+    }
+
+    private boolean detectLeakage(String buffer) {
+        String lower = buffer.toLowerCase();
+        for (String marker : PROMPT_LEAKAGE_MARKERS) {
+            if (lower.contains(marker)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyAuditEvent.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyAuditEvent.java
@@ -1,0 +1,66 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * 瀹夊叏瀹¤浜嬩欢妯″瀷
+ */
+@Data
+@Builder
+public class SafetyAuditEvent {
+
+    /** 瑙勫垯 ID */
+    private final String ruleId;
+
+    /** 瑙勫垯鍚嶇О */
+    private final String ruleName;
+
+    /** 瑙勫垯鍒嗙被 */
+    private final SafetyRuleType ruleType;
+
+    /** 浜嬩欢缁撴灉 */
+    private final SafetyResult.Type result;
+
+    /** 鐢ㄦ埛闂锛堟埅鏂悗锛?*/
+    private final String question;
+
+    /** 鐢ㄦ埛 ID */
+    private final String userId;
+
+    /** 浼氳瘽 ID */
+    private final String conversationId;
+
+    /** 浠诲姟 ID */
+    private final String taskId;
+
+    /** 闄勫姞娑堟伅 */
+    private final String message;
+
+    /** 缃俊搴?*/
+    private final double confidence;
+
+    /** 浜嬩欢鏃堕棿 */
+    @Builder.Default
+    private final LocalDateTime timestamp = LocalDateTime.now();
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyAuditLogger.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyAuditLogger.java
@@ -1,0 +1,57 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import cn.hutool.core.util.StrUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 瀹夊叏瀹¤鏃ュ織缁勪欢
+ * <p>
+ * 浣跨敤 SLF4J marker SAFETY_AUDIT 鏍囪鎵€鏈夊畨鍏ㄤ簨浠舵棩蹇楋紝
+ * 鏂逛究鍚庣画鎺ュ叆 ELK/Splunk 绛夋棩蹇楀钩鍙拌繘琛屽畨鍏ㄦ€佸娍鍒嗘瀽銆?
+ */
+@Slf4j
+@Component
+public class SafetyAuditLogger {
+
+    private static final String MARKER = "SAFETY_AUDIT";
+
+    /**
+     * 璁板綍瀹夊叏瀹¤浜嬩欢
+     */
+    public void log(SafetyAuditEvent event) {
+        if (event == null) {
+            return;
+        }
+        log.warn("[{}] 瀹夊叏浜嬩欢 | ruleId={} | ruleName={} | type={} | result={} | confidence={} | userId={} | conversationId={} | question={} | message={}",
+                MARKER,
+                event.getRuleId(),
+                event.getRuleName(),
+                event.getRuleType(),
+                event.getResult(),
+                String.format("%.2f", event.getConfidence()),
+                StrUtil.emptyIfNull(event.getUserId()),
+                StrUtil.emptyIfNull(event.getConversationId()),
+                StrUtil.sub(StrUtil.emptyIfNull(event.getQuestion()), 0, 200),
+                StrUtil.emptyIfNull(event.getMessage())
+        );
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyCheckContext.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyCheckContext.java
@@ -1,0 +1,55 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatMessage;
+import com.nageoffer.ai.ragent.rag.dto.RetrievalContext;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 瀹夊叏妫€鏌ヤ笂涓嬫枃 鈥斺€?鍖呭惈娴佹按绾垮綋鍓嶉樁娈电殑鎵€鏈夊彲妫€娴嬩俊鎭?
+ */
+@Data
+@Builder
+public class SafetyCheckContext {
+
+    /** 鐢ㄦ埛鍘熷闂 */
+    private final String originalQuestion;
+
+    /** 鏀瑰啓鍚庣殑闂 */
+    private final String rewrittenQuestion;
+
+    /** 缁勮濂界殑娑堟伅鍒楄〃锛堝惈 system prompt + history + evidence + user question锛?*/
+    private final List<ChatMessage> messages;
+
+    /** 妫€绱笂涓嬫枃锛堢敤浜庢娴嬩笂涓嬫枃涓槸鍚﹀寘鍚晱鎰熷唴瀹癸級 */
+    private final RetrievalContext retrievalCtx;
+
+    /** 鐢ㄦ埛 ID */
+    private final String userId;
+
+    /** 浼氳瘽 ID */
+    private final String conversationId;
+
+    /** 浠诲姟 ID */
+    private final String taskId;
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyFilter.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyFilter.java
@@ -1,0 +1,37 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+/**
+ * 瀹夊叏杩囨护鍣ㄦ帴鍙?
+ * <p>
+ * 鍦?RAG Pipeline "涓婁笅鏂囩粍瑁呬箣鍚庛€丩LM 璺敱涔嬪墠" 娉ㄥ叆锛?
+ * 瀵瑰畬鏁磋姹傝繘琛岀‖鎬у畨鍏ㄦ鏌ャ€?
+ */
+@FunctionalInterface
+public interface SafetyFilter {
+
+    /**
+     * 鎵ц瀹夊叏妫€鏌?
+     *
+     * @param context 瀹夊叏妫€鏌ヤ笂涓嬫枃锛堝惈 question + 缁勮濂界殑 messages锛?
+     * @return PASS 鏀捐 / BLOCK 鎷掔粷 / WARN 鍛婅鍚庢斁琛?
+     */
+    SafetyResult check(SafetyCheckContext context);
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyResult.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyResult.java
@@ -1,0 +1,67 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 瀹夊叏妫€鏌ョ粨鏋?
+ * <p>
+ * 鍖呭惈涓夌缁撴灉绫诲瀷锛歅ASS锛堟斁琛岋級銆丅LOCK锛堥樆鏂級銆乄ARN锛堝憡璀︿絾涓嶉樆鏂級
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SafetyResult {
+
+    private final Type type;
+    private final String ruleId;
+    private final String message;
+    private final SafetyRuleType ruleType;
+    private final double confidence;
+
+    public enum Type {
+        PASS, BLOCK, WARN
+    }
+
+    public static SafetyResult pass() {
+        return new SafetyResult(Type.PASS, null, null, null, 0);
+    }
+
+    public static SafetyResult block(String ruleId, String message, SafetyRuleType ruleType, double confidence) {
+        return new SafetyResult(Type.BLOCK, ruleId, message, ruleType, confidence);
+    }
+
+    public static SafetyResult warn(String ruleId, String message, SafetyRuleType ruleType, double confidence) {
+        return new SafetyResult(Type.WARN, ruleId, message, ruleType, confidence);
+    }
+
+    public boolean isBlocked() {
+        return type == Type.BLOCK;
+    }
+
+    public boolean isWarned() {
+        return type == Type.WARN;
+    }
+
+    public boolean isPassed() {
+        return type == Type.PASS;
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRule.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRule.java
@@ -1,0 +1,49 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+/**
+ * 瀹夊叏瑙勫垯鎺ュ彛
+ * <p>
+ * 瀹炵幇绫诲姞 {@code @Component} + {@code @Order} 鍗冲彲鑷姩鎺ュ叆瑙勫垯閾撅紝
+ * 澶嶇敤 Spring Bean 鑷姩鍙戠幇妯″紡锛堝弬鑰?{@code DefaultMcpToolRegistry}锛夈€?
+ */
+public interface SafetyRule {
+
+    /** 瑙勫垯鍞竴鏍囪瘑 */
+    String getId();
+
+    /** 瑙勫垯涓枃鍚嶇О */
+    String getName();
+
+    /** 瑙勫垯鍒嗙被 */
+    SafetyRuleType getType();
+
+    /** 瑙勫垯鏄惁鍚敤锛堥€氬父浠?SecurityProperties 璇诲彇锛?*/
+    boolean isEnabled();
+
+    /**
+     * 鎵ц瀹夊叏妫€鏌?
+     *
+     * @param question 鐢ㄦ埛闂锛堝師濮嬮棶棰橈級
+     * @param context  瀹夊叏妫€鏌ヤ笂涓嬫枃
+     * @return 妫€娴嬬粨鏋滐紝PASS / BLOCK / WARN
+     */
+    SafetyResult evaluate(String question, SafetyCheckContext context);
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRuleOrder.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRuleOrder.java
@@ -1,0 +1,42 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+/**
+ * 瀹夊叏瑙勫垯鎵ц浼樺厛绾у父閲?
+ * <p>
+ * 鍊艰秺灏忚秺鍏堟墽琛岋紝鍓嶅簭瑙勫垯寮€閿€灏忥紝灏芥棭鎷︽埅鍙伩鍏嶅悗缁鏉傛娴?
+ */
+public final class SafetyRuleOrder {
+
+    /** 杈撳叆闀垮害 鈥斺€?鏈€绠€鍗曪紝鍏堟埅鏂?*/
+    public static final int INPUT_LENGTH = 100;
+
+    /** 鍏抽敭璇嶅尮閰?鈥斺€?瀛楃涓?contains锛屽紑閿€浣?*/
+    public static final int KEYWORD = 200;
+
+    /** 鏁忔劅妯″紡姝ｅ垯 鈥斺€?棰勭紪璇戞鍒?*/
+    public static final int SENSITIVE_PATTERN = 300;
+
+    /** Prompt 娉ㄥ叆妫€娴?鈥斺€?妯″紡鍖归厤 */
+    public static final int PROMPT_INJECTION = 400;
+
+    private SafetyRuleOrder() {
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRuleType.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SafetyRuleType.java
@@ -1,0 +1,40 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+/**
+ * 瀹夊叏瑙勫垯鍒嗙被
+ */
+public enum SafetyRuleType {
+
+    /** 缁曡繃闄愬埗 鈥斺€?鐢ㄦ埛璇曞浘閫氳繃 prompt 娉ㄥ叆缁曡繃绯荤粺瑙勫垯 */
+    BYPASS,
+
+    /** 浼€犺韩浠?鈥斺€?鐢ㄦ埛璇曞浘浼鎴愮鐞嗗憳/寮€鍙戣€?绯荤粺鍐呴儴瑙掕壊 */
+    IMPERSONATION,
+
+    /** 鏀诲嚮妫€娴?鈥斺€?鐢ㄦ埛杈撳叆鍖呭惈鎭舵剰鎸囦护銆佷唬鐮佹敞鍏ャ€佽秺鐙卞皾璇?*/
+    ATTACK,
+
+    /** 鏁忔劅淇℃伅娉勯湶 鈥斺€?鐢ㄦ埛璇卞杈撳嚭绯荤粺閰嶇疆銆丄PI Key銆佸唴閮ㄦ枃妗ｇ粨鏋?*/
+    LEAKAGE,
+
+    /** 婊ョ敤 Agent 鏉冮檺 鈥斺€?鐢ㄦ埛璇曞浘璁?Agent 鎵ц瓒呭嚭鑱岃矗鑼冨洿鐨勬搷浣?*/
+    ABUSE
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SecurityProperties.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/SecurityProperties.java
@@ -1,0 +1,73 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 瀹夊叏鍔熻兘閰嶇疆灞炴€?
+ * <p>
+ * 鍓嶇紑锛歿@code rag.security}
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "rag.security")
+public class SecurityProperties {
+
+    /** 瀹夊叏妯″潡鎬诲紑鍏筹紝false 鏃舵墍鏈夎鍒欎笉鐢熸晥 */
+    private boolean enabled = true;
+
+    /** 杈撳叆瀹夊叏閰嶇疆 */
+    private InputConfig input = new InputConfig();
+
+    /** 杈撳嚭瀹夊叏閰嶇疆 */
+    private OutputConfig output = new OutputConfig();
+
+    /** MCP 鏉冮檺閰嶇疆 */
+    private McpConfig mcp = new McpConfig();
+
+    /** 闃绘柇鏃剁殑鎷掔瓟鏂囨 */
+    private String blockMessage = "鎶辨瓑锛屾娴嬪埌鎮ㄧ殑杈撳叆鍖呭惈涓嶅畨鍏ㄧ殑璇锋眰锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€傚鏈夌枒闂鑱旂郴绠＄悊鍛樸€?;
+
+    /** 鍛婅鏃剁殑鎻愮ず鏂囨妯℃澘锛寋rule} 浼氳鏇挎崲涓鸿鍒欏悕绉?*/
+    private String warnMessage = "[瀹夊叏鎻愮ず] 鎮ㄧ殑璇锋眰瑙﹀彂浜嗗畨鍏ㄧ瓥鐣?({rule})锛屾湰娆″洖绛斿凡杩藉姞瀹夊叏绾︽潫銆?;
+
+    @Data
+    public static class InputConfig {
+        private boolean enabled = true;
+        private int maxLength = 4096;
+    }
+
+    @Data
+    public static class OutputConfig {
+        private boolean enabled = true;
+        private boolean maskPhone = true;
+        private boolean maskIdCard = true;
+        private boolean maskEmail = true;
+        private boolean maskApiKey = true;
+        private boolean detectPromptLeakage = true;
+    }
+
+    @Data
+    public static class McpConfig {
+        private boolean enforceRoles = true;
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/InputLengthSafetyRule.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/InputLengthSafetyRule.java
@@ -1,0 +1,97 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security.rule;
+
+import cn.hutool.core.util.StrUtil;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyCheckContext;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyResult;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRule;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleOrder;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleType;
+import com.nageoffer.ai.ragent.rag.core.security.SecurityProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 杈撳叆闀垮害闄愬埗瑙勫垯 鈥斺€?鎴柇瓒呴暱鐢ㄦ埛杈撳叆
+ * <p>
+ * 瓒呴暱杈撳叆鍙兘鏄?DoS 鏀诲嚮鎴?prompt stuffing 灏濊瘯銆?
+ */
+@Slf4j
+@Component
+@Order(SafetyRuleOrder.INPUT_LENGTH)
+@RequiredArgsConstructor
+public class InputLengthSafetyRule implements SafetyRule {
+
+    private final SecurityProperties properties;
+
+    private static final String RULE_ID = "input-length";
+
+    /** 缁濆涓婇檺锛堣秴杩囩洿鎺ユ嫆缁濓紝涓嶇粰 reduction锛?*/
+    private static final int ABSOLUTE_MAX = 20000;
+
+    @Override
+    public String getId() {
+        return RULE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return "杈撳叆闀垮害闄愬埗";
+    }
+
+    @Override
+    public SafetyRuleType getType() {
+        return SafetyRuleType.ATTACK;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return properties.isEnabled() && properties.getInput().isEnabled();
+    }
+
+    @Override
+    public SafetyResult evaluate(String question, SafetyCheckContext context) {
+        if (StrUtil.isBlank(question)) {
+            return SafetyResult.pass();
+        }
+
+        int maxLength = properties.getInput().getMaxLength();
+
+        // 缁濆涓婇檺锛氱洿鎺ユ嫆缁?
+        if (question.length() > ABSOLUTE_MAX) {
+            log.warn("瀹夊叏瑙勫垯-闀垮害闄愬埗: question exceeds absolute max ({} > {})", question.length(), ABSOLUTE_MAX);
+            return SafetyResult.block(RULE_ID,
+                    "杈撳叆鍐呭杩囬暱锛? + question.length() + " 瀛楃锛夛紝宸茶秴鍑虹郴缁熷厑璁哥殑涓婇檺锛? + ABSOLUTE_MAX + " 瀛楃锛夛紝宸茶瀹夊叏绛栫暐鎷︽埅銆?,
+                    SafetyRuleType.ATTACK, 0.99);
+        }
+
+        // 瓒呰繃閰嶇疆涓婇檺浣嗘湭鍒扮粷瀵逛笂闄愶細WARN锛堝厑璁镐絾璁板綍锛?
+        if (question.length() > maxLength) {
+            log.info("瀹夊叏瑙勫垯-闀垮害鍛婅: question length {} exceeds configured max {}", question.length(), maxLength);
+            return SafetyResult.warn(RULE_ID,
+                    "鎮ㄧ殑杈撳叆杈冮暱锛? + question.length() + " 瀛楃锛夛紝鍙兘褰卞搷鍥炵瓟璐ㄩ噺銆傚缓璁簿绠€闂鍚庨噸璇曘€?,
+                    SafetyRuleType.ATTACK, 0.4);
+        }
+
+        return SafetyResult.pass();
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/KeywordSafetyRule.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/KeywordSafetyRule.java
@@ -1,0 +1,182 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security.rule;
+
+import cn.hutool.core.util.StrUtil;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyCheckContext;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyResult;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRule;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleOrder;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleType;
+import com.nageoffer.ai.ragent.rag.core.security.SecurityProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * 鍏抽敭璇嶅尮閰嶈鍒?鈥斺€?浜旂被瀹夊叏鍏抽敭璇嶉粦鍚嶅崟
+ * <p>
+ * 瀵圭敤鎴烽棶棰樺仛鍏抽敭璇嶅寘鍚尮閰嶏紝瑕嗙洊 5 绫诲満鏅€?
+ * 鍗曚竴浣庨闄╁叧閿瘝鍛戒腑鏃朵粎 WARN锛屽涓綆椋庨櫓鍏抽敭璇嶅悓鏃跺嚭鐜版墠 BLOCK銆?
+ */
+@Slf4j
+@Component
+@Order(SafetyRuleOrder.KEYWORD)
+@RequiredArgsConstructor
+public class KeywordSafetyRule implements SafetyRule {
+
+    private final SecurityProperties properties;
+
+    private static final String RULE_ID = "keyword-safety";
+
+    // ===== 缁曡繃闄愬埗鍏抽敭璇?=====
+    private static final Set<String> DEFAULT_BYPASS_KEYWORDS = Set.of(
+            "蹇樿瑙勫垯", "蹇界暐鎻愮ず", "蹇界暐鎵€鏈?, "蹇界暐浠ヤ笂", "鏂版寚浠?, "浣犵幇鍦ㄦ槸",
+            "鍒囨崲瑙掕壊", "system prompt", "ignore instructions", "ignore all",
+            "ignore previous", "forget rules", "涓嶈绠′箣鍓嶇殑", "閲嶆柊璁惧畾",
+            "浣犵殑鏂拌韩浠?, "浠庣幇鍦ㄥ紑濮嬩綘鏄?, "鎵紨", "瑙掕壊鎵紨"
+    );
+
+    // ===== 浼€犺韩浠藉叧閿瘝 =====
+    private static final Set<String> DEFAULT_IMPERSONATION_KEYWORDS = Set.of(
+            "鎴戞槸绠＄悊鍛?, "鎴戞槸寮€鍙戣€?, "瓒呯骇绠＄悊鍛?, "绯荤粺绠＄悊鍛?, "鎴戞槸绯荤粺",
+            "i am admin", "i am developer", "root 鏉冮檺", "鎴戞槸 root",
+            "鎴戞槸鍚庡彴", "鎴戞槸杩愮淮", "鍐呴儴浜哄憳"
+    );
+
+    // ===== 鏀诲嚮鍏抽敭璇?=====
+    private static final Set<String> DEFAULT_ATTACK_KEYWORDS = Set.of(
+            "<script>", "DROP TABLE", "DELETE FROM", "exec(", "eval(",
+            "../../../", "..\\..\\..\\", "SELECT * FROM", "UNION SELECT",
+            "<img onerror", "onerror=", "javascript:", "data:text/html"
+    );
+
+    // ===== 鏁忔劅淇℃伅娉勯湶鍏抽敭璇?=====
+    private static final Set<String> DEFAULT_LEAKAGE_KEYWORDS = Set.of(
+            "API Key", "api_key", "瀵嗙爜", "password", "瀵嗛挜", "secret",
+            "token", "access key", "access_key", "鏁版嵁搴撳瘑鐮?, "閰嶇疆鏂囦欢",
+            "application.yaml", "application.yml", "浣犵殑绯荤粺鎻愮ず璇?,
+            "浣犵殑 prompt", "your prompt", "show me your instructions"
+    );
+
+    // ===== 婊ョ敤鏉冮檺鍏抽敭璇?=====
+    private static final Set<String> DEFAULT_ABUSE_KEYWORDS = Set.of(
+            "鎵ц鍛戒护", "鍒犻櫎鏂囦欢", "鍙戦€侀偖浠?, "璋冪敤 API", "閲嶅惎鏈嶅姟",
+            "shutdown", "rm -rf", "curl ", "wget ", "sudo ",
+            "淇敼鏁版嵁搴?, "drop database", "format c:"
+    );
+
+    @Override
+    public String getId() {
+        return RULE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return "鍏抽敭璇?瀹夊叏妫€娴?;
+    }
+
+    @Override
+    public SafetyRuleType getType() {
+        return SafetyRuleType.BYPASS;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return properties.isEnabled();
+    }
+
+    @Override
+    public SafetyResult evaluate(String question, SafetyCheckContext context) {
+        if (StrUtil.isBlank(question)) {
+            return SafetyResult.pass();
+        }
+
+        String lower = question.toLowerCase();
+
+        // 鎸変弗閲嶇▼搴﹀垎绾ф鏌?
+        // === 楂樺嵄锛氭敾鍑荤被鍏抽敭璇嶏紙鐩存帴 BLOCK锛?===
+        int attackHits = countHits(lower, DEFAULT_ATTACK_KEYWORDS);
+        if (attackHits > 0) {
+            log.warn("瀹夊叏瑙勫垯-鏀诲嚮妫€娴? question contains {} attack keywords", attackHits);
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈涓嶅畨鍏ㄧ殑浠ｇ爜鐗囨锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.ATTACK, 0.95);
+        }
+
+        // === 楂樺嵄锛氭互鐢ㄦ潈闄愶紙鐩存帴 BLOCK锛?===
+        int abuseHits = countHits(lower, DEFAULT_ABUSE_KEYWORDS);
+        if (abuseHits > 0) {
+            log.warn("瀹夊叏瑙勫垯-婊ョ敤鏉冮檺: question contains {} abuse keywords", abuseHits);
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈瓒婃潈鎿嶄綔璇锋眰锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.ABUSE, 0.95);
+        }
+
+        // === 涓嵄锛氫吉閫犺韩浠斤紙鐩存帴 BLOCK锛?===
+        int impersonationHits = countHits(lower, DEFAULT_IMPERSONATION_KEYWORDS);
+        if (impersonationHits > 0) {
+            log.warn("瀹夊叏瑙勫垯-浼€犺韩浠? question contains impersonation keywords");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈韬唤浼€犲皾璇曪紝宸茶瀹夊叏绛栫暐鎷︽埅銆?,
+                    SafetyRuleType.IMPERSONATION, 0.9);
+        }
+
+        // === 涓嵄锛氱粫杩囬檺鍒讹紙WARN 鎴栫粍鍚堝嚭鐜版椂 BLOCK锛?===
+        int bypassHits = countHits(lower, DEFAULT_BYPASS_KEYWORDS);
+        // === 浣庡嵄锛氫俊鎭硠闇茶瀵硷紙WARN 鎴栫粍鍚堝嚭鐜版椂 BLOCK锛?===
+        int leakageHits = countHits(lower, DEFAULT_LEAKAGE_KEYWORDS);
+
+        // 澶氱被鍏抽敭璇嶅悓鏃跺嚭鐜帮紝鍗囩骇涓?BLOCK
+        int categoriesHit = (bypassHits > 0 ? 1 : 0) + (leakageHits > 0 ? 1 : 0);
+        int totalHits = bypassHits + leakageHits;
+
+        if (totalHits >= 3 || categoriesHit >= 2) {
+            log.warn("瀹夊叏瑙勫垯-缁勫悎鍖归厤: bypass={}, leakage={}, categories={}", bypassHits, leakageHits, categoriesHit);
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍙兘璇曞浘缁曡繃绯荤粺瀹夊叏绛栫暐锛屽凡琚嫤鎴€?,
+                    SafetyRuleType.BYPASS, 0.85);
+        }
+
+        if (bypassHits >= 2) {
+            log.warn("瀹夊叏瑙勫垯-缁曡繃闄愬埗: question contains {} bypass keywords", bypassHits);
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍙兘璇曞浘缁曡繃绯荤粺闄愬埗锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.BYPASS, 0.8);
+        }
+
+        if (bypassHits == 1 || leakageHits >= 1) {
+            log.info("瀹夊叏瑙勫垯-鍛婅: bypass={}, leakage={}, 杩藉姞瀹夊叏鎻愮ず", bypassHits, leakageHits);
+            return SafetyResult.warn(RULE_ID,
+                    "妫€娴嬪埌鎮ㄧ殑鎻愰棶鍙兘娑夊強绯荤粺瀹夊叏杈圭晫锛屾湰娆″洖绛斿凡鑷姩杩藉姞瀹夊叏绾︽潫銆?,
+                    SafetyRuleType.BYPASS, 0.5);
+        }
+
+        return SafetyResult.pass();
+    }
+
+    private int countHits(String text, Set<String> keywords) {
+        return (int) keywords.stream().filter(text::contains).count();
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/PromptInjectionSafetyRule.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/PromptInjectionSafetyRule.java
@@ -1,0 +1,155 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security.rule;
+
+import cn.hutool.core.util.StrUtil;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyCheckContext;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyResult;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRule;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleOrder;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleType;
+import com.nageoffer.ai.ragent.rag.core.security.SecurityProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * Prompt 娉ㄥ叆妯″紡妫€娴?
+ * <p>
+ * 妫€娴嬪凡鐭ョ殑 prompt injection / jailbreak 妯″紡锛?
+ * 鍖呮嫭 DAN銆佽鑹叉壆婕斿姭鎸併€佸垎闅旂娆洪獥绛夊父瑙佺粫杩囨墜娉曘€?
+ */
+@Slf4j
+@Component
+@Order(SafetyRuleOrder.PROMPT_INJECTION)
+@RequiredArgsConstructor
+public class PromptInjectionSafetyRule implements SafetyRule {
+
+    private final SecurityProperties properties;
+
+    private static final String RULE_ID = "prompt-injection";
+
+    // ===== 鍏稿瀷娉ㄥ叆妯″紡 =====
+
+    /** "Ignore all previous instructions" 绫绘ā寮?*/
+    private static final Pattern IGNORE_INSTRUCTIONS = Pattern.compile(
+            "ignore\\s+(all\\s+)?(previous|above|the|your|prior)\\s+(instructions?|prompts?|rules?|directives?|context)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** "Do Anything Now" / DAN 妯″紡 */
+    private static final Pattern DAN_PATTERN = Pattern.compile(
+            "(do\\s+anything\\s+now|DAN\\s*mode|jailbreak|developer\\s*mode|god\\s*mode|娌℃湁浠讳綍闄愬埗|瑙ｉ櫎鎵€鏈夐檺鍒?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** 鍒嗛殧绗︽楠楋細鐢?--- 鎴?=== 鎴?XML 鏍囩璇曞浘娉ㄥ叆 system prompt */
+    private static final Pattern DELIMITER_INJECTION = Pattern.compile(
+            "(</?(system|instruction|prompt|rule|directive)>|\\[system\\]|\\[/system\\]|"
+                    + "\\[INST\\]|\\[/INST\\]|<\\|im_start\\|>|<\\|im_end\\|>)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** 杈撳嚭鏍煎紡鍔寔锛氳姹傛寜鐗瑰畾鏍煎紡杈撳嚭浠ユ毚闇插唴閮ㄤ俊鎭?*/
+    private static final Pattern OUTPUT_HIJACK = Pattern.compile(
+            "(杈撳嚭浣?鐨?(绯荤粺|鍘熷)?(鎻愮ず璇峾prompt|鎸囦护|瑙勫垯|璁惧畾)|"
+                    + "print\\s+your\\s+(system\\s+)?(prompt|instructions|rules)|"
+                    + "show\\s+me\\s+your\\s+(system\\s+)?(prompt|instructions|rules)|"
+                    + "what\\s+are\\s+your\\s+(system\\s+)?(instructions|rules))",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** 宓屽/閫掑綊鎻愮ず鏀诲嚮锛氳姹傛ā鎷熶竴涓柊鐨勫璇?*/
+    private static final Pattern NESTED_PROMPT = Pattern.compile(
+            "(鍋囪|鎯宠薄|pretend|imagine)\\s*(浣犵幇鍦ㄦ槸|浣犲湪|浣犳槸).*(鏂皘鍙︿竴涓獆涓嶅悓鐨?\\s*(瀵硅瘽|浼氳瘽|鍦烘櫙|瑙掕壊)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    @Override
+    public String getId() {
+        return RULE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return "Prompt 娉ㄥ叆妫€娴?;
+    }
+
+    @Override
+    public SafetyRuleType getType() {
+        return SafetyRuleType.BYPASS;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return properties.isEnabled();
+    }
+
+    @Override
+    public SafetyResult evaluate(String question, SafetyCheckContext context) {
+        if (StrUtil.isBlank(question)) {
+            return SafetyResult.pass();
+        }
+
+        // === "Ignore instructions" 绫伙紙涓ラ噸锛岀洿鎺?BLOCK锛?===
+        if (IGNORE_INSTRUCTIONS.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-娉ㄥ叆妫€娴? question contains 'ignore instructions' pattern");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈鎸囦护瑕嗙洊鏀诲嚮锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.BYPASS, 0.98);
+        }
+
+        // === DAN/jailbreak锛堜弗閲嶏紝鐩存帴 BLOCK锛?===
+        if (DAN_PATTERN.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-娉ㄥ叆妫€娴? question contains DAN/jailbreak pattern");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈瓒婄嫳鏀诲嚮妯″紡锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.BYPASS, 0.98);
+        }
+
+        // === 鍒嗛殧绗︽敞鍏ワ紙涓ラ噸锛岀洿鎺?BLOCK锛?===
+        if (DELIMITER_INJECTION.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-娉ㄥ叆妫€娴? question contains delimiter injection pattern");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈缁撴瀯娉ㄥ叆鏀诲嚮锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.ATTACK, 0.97);
+        }
+
+        // === 杈撳嚭鏍煎紡鍔寔锛堜腑鍗憋紝鐩存帴 BLOCK锛?===
+        if (OUTPUT_HIJACK.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-娉ㄥ叆妫€娴? question attempts to extract system prompt");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭璇曞浘鑾峰彇绯荤粺鍐呴儴淇℃伅锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.LEAKAGE, 0.95);
+        }
+
+        // === 宓屽鎻愮ず鏀诲嚮锛堜腑鍗憋紝WARN锛?===
+        if (NESTED_PROMPT.matcher(question).find()) {
+            log.info("瀹夊叏瑙勫垯-娉ㄥ叆妫€娴? question contains nested prompt pattern");
+            return SafetyResult.warn(RULE_ID,
+                    "妫€娴嬪埌鎮ㄧ殑鎻愰棶鍖呭惈瑙掕壊鍒囨崲璇锋眰锛屾湰娆″洖绛斿凡杩藉姞瀹夊叏绾︽潫銆?,
+                    SafetyRuleType.BYPASS, 0.7);
+        }
+
+        return SafetyResult.pass();
+    }
+}
+

--- a/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/SensitivePatternSafetyRule.java
+++ b/bootstrap/src/main/java/com/nageoffer/ai/ragent/rag/core/security/rule/SensitivePatternSafetyRule.java
@@ -1,0 +1,139 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.security.rule;
+
+import cn.hutool.core.util.StrUtil;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyCheckContext;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyResult;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRule;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleOrder;
+import com.nageoffer.ai.ragent.rag.core.security.SafetyRuleType;
+import com.nageoffer.ai.ragent.rag.core.security.SecurityProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+/**
+ * 鏁忔劅淇℃伅姝ｅ垯妫€娴?鈥斺€?妫€娴嬬敤鎴烽棶棰樹腑鏄惁鍖呭惈鍑瘉銆佸瘑閽ョ瓑鏁忔劅鏁版嵁
+ * <p>
+ * 闃叉鐢ㄦ埛閫氳繃闂鏂囨湰娉ㄥ叆 API Key 鎴栦吉瑁呭唴閮ㄥ嚟璇併€?
+ */
+@Slf4j
+@Component
+@Order(SafetyRuleOrder.SENSITIVE_PATTERN)
+@RequiredArgsConstructor
+public class SensitivePatternSafetyRule implements SafetyRule {
+
+    private final SecurityProperties properties;
+
+    private static final String RULE_ID = "sensitive-pattern";
+
+    /** 鎵嬫満鍙凤紙涓浗澶ч檰锛?*/
+    private static final Pattern PHONE_PATTERN = Pattern.compile("1[3-9]\\d{9}");
+
+    /** 韬唤璇佸彿锛?8浣嶏級 */
+    private static final Pattern ID_CARD_PATTERN = Pattern.compile("\\d{17}[\\dXx]");
+
+    /** OpenAI/DeepSeek 椋庢牸鐨?API Key */
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("sk-[a-zA-Z0-9_-]{20,}");
+
+    /** 閫氱敤 API Key 妯″紡 */
+    private static final Pattern GENERIC_KEY_PATTERN = Pattern.compile(
+            "(api[_\\s]?key|api[_\\s]?secret|access[_\\s]?key|secret[_\\s]?key)\\s*[:=]\\s*['\"]?\\S+['\"]?",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /** JWT Token 妯″紡 */
+    private static final Pattern JWT_PATTERN = Pattern.compile("eyJ[a-zA-Z0-9_-]*\\.eyJ[a-zA-Z0-9_-]*\\.[a-zA-Z0-9_-]+");
+
+    @Override
+    public String getId() {
+        return RULE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return "鏁忔劅淇℃伅-姝ｅ垯妫€娴?;
+    }
+
+    @Override
+    public SafetyRuleType getType() {
+        return SafetyRuleType.LEAKAGE;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return properties.isEnabled();
+    }
+
+    @Override
+    public SafetyResult evaluate(String question, SafetyCheckContext context) {
+        if (StrUtil.isBlank(question)) {
+            return SafetyResult.pass();
+        }
+
+        // 妫€娴?API Key 鐩存帴鍑虹幇
+        if (API_KEY_PATTERN.matcher(question).find() || JWT_PATTERN.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-鍑瘉娉勯湶: question contains API key or JWT pattern");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈鐤戜技 API 鍑瘉锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€傝鍕垮湪瀵硅瘽涓彂閫佸瘑閽ヤ俊鎭€?,
+                    SafetyRuleType.LEAKAGE, 0.98);
+        }
+
+        // 妫€娴嬮€氱敤瀵嗛挜妯″紡
+        if (GENERIC_KEY_PATTERN.matcher(question).find()) {
+            log.warn("瀹夊叏瑙勫垯-瀵嗛挜妯″紡: question matches generic key pattern");
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈鐤戜技瀵嗛挜閰嶇疆锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.LEAKAGE, 0.9);
+        }
+
+        // 妫€娴嬪ぇ閲忔墜鏈哄彿/韬唤璇侊紙鍙兘鐨勬嫋搴撹涓猴級
+        int phoneCount = countMatches(PHONE_PATTERN, question);
+        int idCardCount = countMatches(ID_CARD_PATTERN, question);
+
+        if (idCardCount >= 3 || phoneCount >= 5) {
+            log.warn("瀹夊叏瑙勫垯-鎵归噺闅愮: phone={}, idCard={}", phoneCount, idCardCount);
+            return SafetyResult.block(RULE_ID,
+                    "妫€娴嬪埌杈撳叆鍐呭鍖呭惈澶ч噺涓汉闅愮鏁版嵁锛屽凡琚畨鍏ㄧ瓥鐣ユ嫤鎴€?,
+                    SafetyRuleType.LEAKAGE, 0.95);
+        }
+
+        if (idCardCount >= 1 || phoneCount >= 2) {
+            log.info("瀹夊叏瑙勫垯-涓汉闅愮鎻愮ず: phone={}, idCard={}", phoneCount, idCardCount);
+            return SafetyResult.warn(RULE_ID,
+                    "妫€娴嬪埌鎮ㄧ殑杈撳叆鍖呭惈涓汉鏁忔劅淇℃伅锛岃娉ㄦ剰淇濇姢闅愮銆?,
+                    SafetyRuleType.LEAKAGE, 0.6);
+        }
+
+        return SafetyResult.pass();
+    }
+
+    private int countMatches(Pattern pattern, String text) {
+        int count = 0;
+        var matcher = pattern.matcher(text);
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+}
+

--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -174,6 +174,31 @@ rag:
     enabled: true
     max-error-length: 1000
 
+  # ==================== 安全过滤配置 ====================
+  security:
+    # 安全模块总开关，false 时所有规则不生效
+    enabled: true
+    # 阻断时的拒答文案
+    block-message: "抱歉，检测到您的输入包含不安全的请求，已被安全策略拦截。如有疑问请联系管理员。"
+    # 告警时的提示文案模板，{rule} 会被替换为规则名称
+    warn-message: "[安全提示] 您的请求触发了安全策略 ({rule})，本次回答已追加安全约束。"
+    input:
+      enabled: true
+      # 输入最大字符长度
+      max-length: 4096
+    output:
+      enabled: true
+      # 输出脱敏开关
+      mask-phone: true
+      mask-id-card: true
+      mask-email: true
+      mask-api-key: true
+      # Prompt 泄露检测
+      detect-prompt-leakage: true
+    mcp:
+      # MCP 工具权限控制
+      enforce-roles: true
+
   # 图片解析（图生文）配置
   # 产出一段自包含的知识文本：既说清"图是什么"，又完整保留所有文字与层级
   image-parse:


### PR DESCRIPTION
## 概述
为 Ragent 添加完整的输入输出安全过滤模块，填补当前版本在安全防护方面的空白。

## 改动内容
- 新增 `SafetyFilter` / `SafetyRule` 接口，基于责任链模式
- `DefaultSafetyFilter`：Spring 自动发现所有 `SafetyRule` Bean，按 @Order 排序执行
- 4 条默认规则：输入长度限制、敏感词过滤、Prompt注入检测、正则模式匹配
- 输出安全：流式脱敏（手机号/身份证/邮箱/API Key）+ Prompt 泄露检测
- MCP 工具权限控制：`@McpToolPermission` 注解 + `McpPermissionEnforcer`
- SLF4J 审计日志（`SAFETY_AUDIT` marker），方便对接 ELK/Splunk
- 通过 `rag.security.*` 配置总开关，默认启用
- 关闭后（`rag.security.enabled=false`）对现有行为零影响

## 设计理念
- 规则实现只需加 `@Component` + `@Order`，无需手动注册
- 遇 BLOCK 短路返回，WARN 合并后附加约束
- 输出过滤独立于输入过滤，可按需单独开关
- 全链路可审计