### PR TITLE
fix(chat): 修复 SSE 流异常处理导致的二次错误

### DIFF
--- a/framework/src/main/java/com/nageoffer/ai/ragent/framework/web/SseEmitterSender.java
+++ b/framework/src/main/java/com/nageoffer/ai/ragent/framework/web/SseEmitterSender.java
@@ -20,6 +20,7 @@ package com.nageoffer.ai.ragent.framework.web;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -74,8 +75,9 @@ public class SseEmitterSender {
                 return;
             }
             emitter.send(SseEmitter.event().name(eventName).data(data));
-        } catch (Exception e) {
-            fail(e);
+        } catch (IOException e) {
+            closed.set(true);
+            log.warn("SSE connection closed while sending event", e);
         }
     }
 
@@ -92,34 +94,4 @@ public class SseEmitterSender {
         }
     }
 
-    /**
-     * 异常结束并关闭 SSE 连接
-     *
-     * <p>当发生异常时调用此方法，会执行以下操作：</p>
-     * <ol>
-     *   <li>关闭 SSE 连接并通知客户端异常信息</li>
-     *   <li>不再抛出异常，避免在流式响应已开始后触发全局异常处理器导致响应冲突</li>
-     * </ol>
-     *
-     * @param throwable 导致失败的异常对象
-     */
-    public void fail(Throwable throwable) {
-        closeWithError(throwable);
-        log.warn("SSE send failed", throwable);
-    }
-
-    /**
-     * 内部方法：以异常方式关闭连接
-     * <p>
-     * 使用 CAS 操作确保连接只被关闭一次
-     * 调用 SseEmitter 的 completeWithError 方法，通知客户端连接异常终止
-     *
-     * @param throwable 导致连接关闭的异常对象
-     */
-    private void closeWithError(Throwable throwable) {
-        // 使用 CAS 原子操作，确保只关闭一次
-        if (closed.compareAndSet(false, true)) {
-            emitter.completeWithError(throwable);
-        }
-    }
 }

--- a/framework/src/test/java/com/nageoffer/ai/ragent/framework/web/SseEmitterSenderTest.java
+++ b/framework/src/test/java/com/nageoffer/ai/ragent/framework/web/SseEmitterSenderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.framework.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class SseEmitterSenderTest {
+
+    @Test
+    void sendIOExceptionShouldNotTriggerAsyncErrorDispatch() throws Exception {
+        SseEmitter emitter = mock(SseEmitter.class);
+        doThrow(new IOException("client disconnected"))
+                .when(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        SseEmitterSender sender = new SseEmitterSender(emitter);
+
+        sender.sendEvent("message", "content");
+        sender.sendEvent("message", "ignored");
+
+        verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        verify(emitter, never()).complete();
+        verify(emitter, never()).completeWithError(any());
+    }
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/StreamErrorPayload.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/StreamErrorPayload.java
@@ -15,57 +15,12 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.rag.enums;
-
-import lombok.RequiredArgsConstructor;
+package com.nageoffer.ai.ragent.rag.dto;
 
 /**
- * SSE 事件类型枚举
+ * 流式对话错误事件载荷
+ *
+ * @param error 面向用户的错误提示
  */
-@RequiredArgsConstructor
-public enum SSEEventType {
-
-    /**
-     * 会话与任务的元信息事件
-     */
-    META("meta"),
-
-    /**
-     * 增量消息事件
-     */
-    MESSAGE("message"),
-
-    /**
-     * 模型回复完成事件
-     */
-    FINISH("finish"),
-
-    /**
-     * 完成事件
-     */
-    DONE("done"),
-
-    /**
-     * 取消事件
-     */
-    CANCEL("cancel"),
-
-    /**
-     * 错误事件
-     */
-    ERROR("error"),
-
-    /**
-     * 拒绝事件
-     */
-    REJECT("reject");
-
-    private final String value;
-
-    /**
-     * SSE 事件名称（与前端约定一致）
-     */
-    public String value() {
-        return value;
-    }
+public record StreamErrorPayload(String error) {
 }

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamChatEventHandler.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamChatEventHandler.java
@@ -23,6 +23,7 @@ import com.nageoffer.ai.ragent.rag.dao.entity.ConversationDO;
 import com.nageoffer.ai.ragent.rag.dto.CompletionPayload;
 import com.nageoffer.ai.ragent.rag.dto.MessageDelta;
 import com.nageoffer.ai.ragent.rag.dto.MetaPayload;
+import com.nageoffer.ai.ragent.rag.dto.StreamErrorPayload;
 import com.nageoffer.ai.ragent.rag.enums.SSEEventType;
 import com.nageoffer.ai.ragent.framework.context.UserContext;
 import com.nageoffer.ai.ragent.framework.convention.ChatMessage;
@@ -44,6 +45,7 @@ public class StreamChatEventHandler implements StreamCallback {
 
     private static final String TYPE_THINK = "think";
     private static final String TYPE_RESPONSE = "response";
+    private static final String ERROR_MESSAGE = "生成失败，请稍后重试";
 
     private final int messageChunkSize;
     private final SseEmitterSender sender;
@@ -237,8 +239,10 @@ public class StreamChatEventHandler implements StreamCallback {
         if (taskManager.isCancelled(taskId)) {
             return;
         }
+        log.error("流式对话失败，conversationId：{}，taskId：{}", conversationId, taskId, t);
         taskManager.unregister(taskId);
-        sender.fail(t);
+        sender.sendEvent(SSEEventType.ERROR.value(), new StreamErrorPayload(ERROR_MESSAGE));
+        sender.complete();
     }
 
     private void sendChunked(String type, String content) {

--- a/rag/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/StreamChatEventHandlerTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/StreamChatEventHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.framework.web.StreamTaskManager;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.rag.core.memory.ConversationMemoryService;
+import com.nageoffer.ai.ragent.rag.service.ConversationGroupService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StreamChatEventHandlerTest {
+
+    private static final String PUBLIC_ERROR_MESSAGE = "生成失败，请稍后重试";
+
+    @Mock
+    private SseEmitter emitter;
+
+    @Mock
+    private AIModelProperties modelProperties;
+
+    @Mock
+    private ConversationMemoryService memoryService;
+
+    @Mock
+    private ConversationGroupService conversationGroupService;
+
+    @Mock
+    private StreamTaskManager taskManager;
+
+    @Test
+    void businessFailureShouldSendSafeErrorEventAndCompleteNormally() throws Exception {
+        StreamChatEventHandler handler = new StreamChatEventHandler(StreamChatHandlerParams.builder()
+                .emitter(emitter)
+                .conversationId("conversation-1")
+                .taskId("task-1")
+                .modelProperties(modelProperties)
+                .memoryService(memoryService)
+                .conversationGroupService(conversationGroupService)
+                .taskManager(taskManager)
+                .build());
+
+        handler.onError(new IllegalStateException("database password leaked"));
+
+        ArgumentCaptor<SseEmitter.SseEventBuilder> eventCaptor =
+                ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+        verify(emitter, times(2)).send(eventCaptor.capture());
+        List<Object> errorEventData = eventCaptor.getAllValues().get(1).build().stream()
+                .map(ResponseBodyEmitter.DataWithMediaType::getData)
+                .toList();
+        assertTrue(errorEventData.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .anyMatch(data -> data.startsWith("event:error\n")));
+        Object payload = errorEventData.stream()
+                .filter(data -> !(data instanceof String))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(PUBLIC_ERROR_MESSAGE, ReflectionTestUtils.getField(payload, "error"));
+        assertFalse(payload.toString().contains("database password leaked"));
+        verify(taskManager).unregister("task-1");
+        verify(emitter).complete();
+        verify(emitter, never()).completeWithError(any());
+    }
+}


### PR DESCRIPTION
## 问题背景

流式对话发生业务异常时，当前逻辑会调用 `SseEmitter.completeWithError()`。

该方法会触发一次异步错误分发。由于响应类型已经被设置为 `text/event-stream`，后续全局异常处理返回的普通 JSON 响应无法按照 SSE 类型写出，进而产生 `HttpMessageNotWritableException` 等二次异常。

与此同时，前端无法收到已经支持的 `error` SSE 事件，只能感知到连接异常结束。

## 修复内容

- 新增 SSE `error` 事件类型。
- 新增流式错误事件载荷，仅返回面向用户的固定错误提示。
- 流式业务异常发生时：
  - 在服务端记录原始异常；
  - 注销流式任务；
  - 向客户端发送 `error` 事件；
  - 使用 `complete()` 正常结束 SSE 响应。
- SSE 发送发生 `IOException` 时，仅标记连接关闭，不再调用 `completeWithError()`，避免触发二次错误分发。
- 增加针对业务异常和客户端断连场景的回归测试。

## 影响范围

本次修改仅影响流式对话的异常结束路径。

正常消息、思考过程、完成事件、取消事件及队列限流逻辑保持不变。

## 测试

相关测试类共 4 个，全部通过：

- `SseEmitterSenderTest`
  - 验证客户端断连后不会调用 `completeWithError()`。
  - 验证连接关闭后不会继续发送事件。
- `StreamChatEventHandlerTest`
  - 验证业务异常会发送 `error` SSE 事件。
  - 验证响应不会暴露原始异常信息。
  - 验证任务注销并正常结束 SSE 响应。
- `StreamChatPipelineTest`
- `ChatQueueLimiterTest`
