### PR TITLE
feat(voice): 新增基于 WebSocket 连接池的流式 TTS 消息播放

### DIFF
--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -121,6 +121,11 @@ rag:
         max-pool-size: 32
         keep-alive-seconds: 60
         thread-name-prefix: websocket_lifecycle_executor_
+      playback:
+        core-pool-size: 2
+        max-pool-size: 8
+        keep-alive-seconds: 60
+        thread-name-prefix: voice_playback_executor_
 
   memory:
     history-keep-turns: 8

--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -207,9 +207,11 @@ ai:
     bailian:
       url: https://dashscope.aliyuncs.com
       api-key: ${BAILIAN_API_KEY:}
+      workspace: ${BAILIAN_WORKSPACE:}
       endpoints:
         chat: /compatible-mode/v1/chat/completions
         rerank: /api/v1/services/rerank/text-rerank/text-rerank
+        tts: /api-ws/v1/inference
     aihubmix:
       url: https://aihubmix.com
       api-key: ${AIHUBMIX_API_KEY:}
@@ -304,6 +306,16 @@ ai:
       - id: qwen-vl-max
         provider: bailian
         model: qwen-vl-max
+
+  tts:
+    default-model: cosyvoice-v3-flash
+    timeout-ms: 3000
+    candidates:
+      - id: cosyvoice-v3-flash
+        provider: bailian
+        model: cosyvoice-v3-flash
+        priority: 1
+        voice: longxiaochun_v3
 
   websocket:
     connect-timeout-ms: 10000

--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -114,6 +114,14 @@ rag:
       lease-seconds: 30
       poll-interval-ms: 200
 
+  voice:
+    executors:
+      websocket-lifecycle:
+        core-pool-size: 2
+        max-pool-size: 32
+        keep-alive-seconds: 60
+        thread-name-prefix: websocket_lifecycle_executor_
+
   memory:
     history-keep-turns: 8
     summary-enabled: true
@@ -296,6 +304,15 @@ ai:
       - id: qwen-vl-max
         provider: bailian
         model: qwen-vl-max
+
+  websocket:
+    connect-timeout-ms: 10000
+    task-start-timeout-ms: 10000
+    task-packet-idle-timeout-ms: 10000
+    max-total-per-model: 8
+    max-idle-per-model: 8
+    idle-timeout-ms: 25000
+    eviction-interval-ms: 30000
 
 # MinerU SaaS API 配置（PDF / Word / PPT 走 MinerU 解析）
 mineru:

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackEventHandlerTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackEventHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.framework.web.StreamTaskManager;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class VoicePlaybackEventHandlerTest {
+
+    private static final String TASK_ID = "task-1";
+
+    @Test
+    void sendsAudioAndCompletesThroughSse() throws Exception {
+        SseEmitter emitter = mock(SseEmitter.class);
+        StreamTaskManager taskManager = mock(StreamTaskManager.class);
+        VoicePlaybackEventHandler handler = new VoicePlaybackEventHandler(emitter, TASK_ID, taskManager);
+
+        handler.onAudio(new byte[]{1, 2});
+        handler.onComplete();
+
+        verify(taskManager).register(any(String.class), any(Runnable.class));
+        verify(emitter, times(3)).send(any(SseEmitter.SseEventBuilder.class));
+        verify(taskManager).unregister(TASK_ID);
+        verify(emitter).complete();
+    }
+
+    @Test
+    void reportsOnlyFirstError() {
+        SseEmitter emitter = mock(SseEmitter.class);
+        StreamTaskManager taskManager = mock(StreamTaskManager.class);
+        VoicePlaybackEventHandler handler = new VoicePlaybackEventHandler(emitter, TASK_ID, taskManager);
+        RuntimeException failure = new RuntimeException("failed");
+
+        handler.onError(failure);
+        handler.onError(new RuntimeException("duplicate"));
+
+        verify(taskManager).unregister(TASK_ID);
+        verify(emitter).completeWithError(failure);
+    }
+
+    @Test
+    void cancelsTaskWhenEmitterCompletes() {
+        SseEmitter emitter = mock(SseEmitter.class);
+        StreamTaskManager taskManager = mock(StreamTaskManager.class);
+        new VoicePlaybackEventHandler(emitter, TASK_ID, taskManager);
+        ArgumentCaptor<Runnable> callbacks = ArgumentCaptor.forClass(Runnable.class);
+        verify(emitter, times(2)).onCompletion(callbacks.capture());
+
+        List<Runnable> completionCallbacks = callbacks.getAllValues();
+        completionCallbacks.get(1).run();
+
+        verify(taskManager).cancel(TASK_ID);
+        verify(taskManager, never()).unregister(TASK_ID);
+    }
+
+    @Test
+    void bindsProviderCancellationHandleToTask() {
+        SseEmitter emitter = mock(SseEmitter.class);
+        StreamTaskManager taskManager = mock(StreamTaskManager.class);
+        StreamCancellationHandle providerHandle = mock(StreamCancellationHandle.class);
+        VoicePlaybackEventHandler handler = new VoicePlaybackEventHandler(emitter, TASK_ID, taskManager);
+        ArgumentCaptor<Runnable> handle = ArgumentCaptor.forClass(Runnable.class);
+
+        handler.onTaskStarted(providerHandle);
+        verify(taskManager).bindHandle(eq(TASK_ID), handle.capture());
+        handle.getValue().run();
+
+        verify(providerHandle).cancel();
+    }
+}

--- a/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackTaskRunnerTest.java
+++ b/bootstrap/src/test/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackTaskRunnerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.infra.voice.tts.TtsService;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class VoicePlaybackTaskRunnerTest {
+
+    private static final String TEXT = "你好";
+
+    @Test
+    void startsTtsThroughPlaybackExecutor() {
+        TtsService ttsService = mock(TtsService.class);
+        VoicePlaybackEventHandler callback = mock(VoicePlaybackEventHandler.class);
+        VoicePlaybackTaskRunner runner = new VoicePlaybackTaskRunner(ttsService, Runnable::run);
+
+        runner.run(TEXT, callback);
+
+        verify(ttsService).synthesize(TEXT, callback, callback);
+    }
+
+    @Test
+    void skipsTtsWhenTaskWasCancelled() {
+        TtsService ttsService = mock(TtsService.class);
+        VoicePlaybackEventHandler callback = mock(VoicePlaybackEventHandler.class);
+        when(callback.isCancelled()).thenReturn(true);
+        VoicePlaybackTaskRunner runner = new VoicePlaybackTaskRunner(ttsService, Runnable::run);
+
+        runner.run(TEXT, callback);
+
+        verify(ttsService, never()).synthesize(TEXT, callback, callback);
+    }
+
+    @Test
+    void delegatesStartFailureToCallback() {
+        TtsService ttsService = mock(TtsService.class);
+        VoicePlaybackEventHandler callback = mock(VoicePlaybackEventHandler.class);
+        RuntimeException failure = new RuntimeException("failed");
+        doThrow(failure).when(ttsService).synthesize(TEXT, callback, callback);
+        VoicePlaybackTaskRunner runner = new VoicePlaybackTaskRunner(ttsService, Runnable::run);
+
+        runner.run(TEXT, callback);
+
+        verify(callback).onStartFailure(failure);
+    }
+
+    @Test
+    void delegatesExecutorRejectionToCallback() {
+        TtsService ttsService = mock(TtsService.class);
+        VoicePlaybackEventHandler callback = mock(VoicePlaybackEventHandler.class);
+        Executor rejectingExecutor = command -> {
+            throw new RejectedExecutionException("busy");
+        };
+        VoicePlaybackTaskRunner runner = new VoicePlaybackTaskRunner(ttsService, rejectingExecutor);
+
+        runner.run(TEXT, callback);
+
+        verify(callback).onRejected(any(RejectedExecutionException.class));
+    }
+}

--- a/frontend/src/components/chat/FeedbackButtons.tsx
+++ b/frontend/src/components/chat/FeedbackButtons.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { ThumbDownFilledIcon, ThumbUpFilledIcon } from "@/components/chat/ThumbIcons";
+import { VoicePlayButton } from "@/components/chat/VoicePlayButton";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +20,8 @@ interface FeedbackButtonsProps {
   messageId: string;
   feedback: FeedbackValue;
   content: string;
+  playing?: boolean;
+  onTogglePlay?: () => void;
   className?: string;
   alwaysVisible?: boolean;
 }
@@ -31,6 +34,8 @@ export function FeedbackButtons({
   messageId,
   feedback,
   content,
+  playing,
+  onTogglePlay,
   className,
   alwaysVisible
 }: FeedbackButtonsProps) {
@@ -171,6 +176,7 @@ export function FeedbackButtons({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+      {onTogglePlay ? <VoicePlayButton playing={Boolean(playing)} onToggle={onTogglePlay} /> : null}
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/src/components/chat/MessageItem.tsx
+++ b/frontend/src/components/chat/MessageItem.tsx
@@ -3,6 +3,7 @@ import { Brain, ChevronDown } from "lucide-react";
 
 import { FeedbackButtons } from "@/components/chat/FeedbackButtons";
 import { MarkdownRenderer } from "@/components/chat/MarkdownRenderer";
+import { useVoicePlayback } from "@/hooks/useVoicePlayback";
 import { RecommendedQuestions } from "@/components/chat/RecommendedQuestions";
 import { RecommendedQuestionsButton } from "@/components/chat/RecommendedQuestionsButton";
 import { SourcesButton } from "@/components/chat/SourcesButton";
@@ -33,6 +34,7 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
     Boolean(message.id) &&
     (message.messageStatus ?? "NORMAL") === "NORMAL" &&
     !message.id.startsWith("assistant-");
+  const { playingId, togglePlay } = useVoicePlayback();
   const [thinkingExpanded, setThinkingExpanded] = React.useState(false);
   const hasThinking = Boolean(message.thinking && message.thinking.trim().length > 0);
   const hasContent = message.content.trim().length > 0;
@@ -116,6 +118,8 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
                   messageId={message.id}
                   feedback={message.feedback ?? null}
                   content={message.content}
+                  playing={playingId === message.id}
+                  onTogglePlay={() => togglePlay(message.id)}
                   alwaysVisible
                 />
               ) : null}

--- a/frontend/src/components/chat/VoicePlayButton.tsx
+++ b/frontend/src/components/chat/VoicePlayButton.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Volume2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface VoicePlayButtonProps {
+  playing: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * 消息语音播放按钮 播放中高亮 点击停止
+ */
+export function VoicePlayButton({ playing, onToggle }: VoicePlayButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      type="button"
+      onClick={onToggle}
+      aria-label={playing ? "停止播放" : "播放语音"}
+      className={cn(
+        "h-7 w-7 rounded-md hover:bg-[#F5F5F5]",
+        playing ? "text-[#1A1A1A]" : "text-[#999999] hover:text-[#666666]"
+      )}
+    >
+      <Volume2 className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/frontend/src/hooks/useVoicePlayback.ts
+++ b/frontend/src/hooks/useVoicePlayback.ts
@@ -1,0 +1,237 @@
+import { useChatStore } from "@/stores/chatStore";
+
+import { createStreamResponse } from "@/hooks/useStreamResponse";
+import { storage } from "@/utils/storage";
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/$/, "");
+const PLAY_URL = `${API_BASE_URL}/rag/v3/voice/play`;
+const STOP_URL = `${API_BASE_URL}/rag/v3/voice/stop`;
+
+interface AudioMetaPayload {
+  taskId?: string;
+}
+
+// 播放器单例 全局只播一条
+let streamRef: ReturnType<typeof createStreamResponse> | null = null;
+let requestStopRef: (() => void) | null = null;
+let mediaSourceRef: MediaSource | null = null;
+let sourceBufferRef: SourceBuffer | null = null;
+let audioElRef: HTMLAudioElement | null = null;
+let objectUrlRef: string | null = null;
+let appendQueue: Uint8Array[] = [];
+let appendPending = false;
+
+function stopInternal() {
+  const requestStop = requestStopRef;
+  streamRef = null;
+  requestStopRef = null;
+  requestStop?.();
+  if (audioElRef) {
+    audioElRef.pause();
+    audioElRef.removeAttribute("src");
+    audioElRef = null;
+  }
+  if (objectUrlRef) {
+    URL.revokeObjectURL(objectUrlRef);
+    objectUrlRef = null;
+  }
+  if (mediaSourceRef && mediaSourceRef.readyState !== "closed") {
+    try {
+      mediaSourceRef.endOfStream();
+    } catch {
+      // 流已关闭
+    }
+  }
+  mediaSourceRef = null;
+
+  sourceBufferRef = null;
+  appendQueue = [];
+  appendPending = false;
+}
+
+/**
+ * MSE 流式播放 MP3
+ */
+function playInternal(messageId: string) {
+  stopInternal();
+
+  if (!("MediaSource" in window)) {
+    setPlaying(null);
+    return;
+  }
+  if (!MediaSource.isTypeSupported("audio/mpeg")) {
+    setPlaying(null);
+    return;
+  }
+
+  let playStarted = false;
+  let streamEnded = false;
+  let taskId: string | null = null;
+  let cancelRequested = false;
+  let stopRequested = false;
+  const mediaSource = new MediaSource();
+  mediaSourceRef = mediaSource;
+  const audio = new Audio();
+  audioElRef = audio;
+
+  const requestStop = () => {
+    cancelRequested = true;
+    if (!taskId || stopRequested) return;
+    stopRequested = true;
+    const token = storage.getToken();
+    fetch(`${STOP_URL}?taskId=${encodeURIComponent(taskId)}`, {
+      method: "POST",
+      headers: token ? { Authorization: token } : undefined
+    }).catch(() => null);
+  };
+
+  const endStreamIfReady = () => {
+    if (
+      !streamEnded ||
+      appendPending ||
+      appendQueue.length > 0 ||
+      !sourceBufferRef ||
+      sourceBufferRef.updating ||
+      mediaSource.readyState !== "open"
+    ) {
+      return;
+    }
+    try {
+      mediaSource.endOfStream();
+    } catch {
+      // 流已关闭
+    }
+  };
+
+  const flushAppendQueue = () => {
+    if (appendPending || !sourceBufferRef || appendQueue.length === 0) return;
+    const next = appendQueue.shift()!;
+    appendPending = true;
+    try {
+      sourceBufferRef.appendBuffer(next);
+      // 首帧入缓冲后开始播放
+      if (!playStarted) {
+        playStarted = true;
+        audio.play().catch(() => {
+          if (audioElRef === audio) {
+            stopInternal();
+            setPlaying(null);
+          }
+        });
+      }
+    } catch {
+      appendPending = false;
+    }
+  };
+
+  mediaSource.addEventListener("sourceopen", () => {
+    try {
+      sourceBufferRef = mediaSource.addSourceBuffer("audio/mpeg");
+      // MP3 没有可供 MSE 排序的时间戳
+      sourceBufferRef.mode = "sequence";
+      sourceBufferRef.addEventListener("updateend", () => {
+        appendPending = false;
+        flushAppendQueue();
+        endStreamIfReady();
+      });
+      // 补排 sourceopen 前收到的音频帧
+      flushAppendQueue();
+      endStreamIfReady();
+    } catch {
+      setPlaying(null);
+    }
+  });
+
+  audio.onerror = () => setPlaying(null);
+  audio.onended = () => setPlaying(null);
+
+  const handlers = {
+    onEvent(event: string, payload: unknown) {
+      if (event === "audio-meta") {
+        const meta = payload as AudioMetaPayload;
+        taskId = meta?.taskId ?? null;
+        if (cancelRequested) {
+          requestStop();
+        }
+      }
+      if (streamRef !== stream) return;
+      if (event === "audio") {
+        const frame = payload as { base64?: string };
+        if (!frame?.base64) return;
+        const bytes = Uint8Array.from(atob(frame.base64), (c) => c.charCodeAt(0));
+        appendQueue.push(bytes);
+        flushAppendQueue();
+      } else if (event === "done") {
+        streamRef = null;
+        requestStopRef = null;
+        streamEnded = true;
+        endStreamIfReady();
+      }
+    },
+    onError() {
+      if (streamRef !== stream) return;
+      streamRef = null;
+      requestStopRef = null;
+      // 保留已缓冲音频
+      streamEnded = true;
+      endStreamIfReady();
+      setPlaying(null);
+    }
+  };
+
+  const token = storage.getToken();
+  const stream = createStreamResponse(
+    {
+      url: `${PLAY_URL}?messageId=${encodeURIComponent(messageId)}`,
+      headers: token ? { Authorization: token } : undefined,
+      retryCount: 0
+    },
+    handlers
+  );
+  streamRef = stream;
+  requestStopRef = requestStop;
+
+  if (objectUrlRef) {
+    URL.revokeObjectURL(objectUrlRef);
+  }
+  objectUrlRef = URL.createObjectURL(mediaSource);
+  audio.src = objectUrlRef;
+
+  stream.start().catch(() => {
+    if (streamRef === stream) {
+      stopInternal();
+      setPlaying(null);
+    }
+  });
+  setPlaying(messageId);
+}
+
+function setPlaying(messageId: string | null) {
+  useChatStore.setState({ playingMessageId: messageId });
+}
+
+/**
+ * 停止当前语音播放
+ */
+export function stopVoicePlayback() {
+  stopInternal();
+  setPlaying(null);
+}
+
+/**
+ * 消息语音播放
+ */
+export function useVoicePlayback() {
+  const playingId = useChatStore((state) => state.playingMessageId);
+
+  const togglePlay = (messageId: string) => {
+    if (playingId === messageId) {
+      stopInternal();
+      setPlaying(null);
+      return;
+    }
+    playInternal(messageId);
+  };
+
+  return { playingId, togglePlay };
+}

--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -22,6 +22,7 @@ import {
 } from "@/services/chatService";
 import { buildQuery } from "@/utils/helpers";
 import { createStreamResponse } from "@/hooks/useStreamResponse";
+import { stopVoicePlayback } from "@/hooks/useVoicePlayback";
 import { storage } from "@/utils/storage";
 
 interface ChatState {
@@ -42,6 +43,8 @@ interface ChatState {
   openedSourceMessageId: string | null;
   // 展开推荐面板后需滚入视口的消息；每次请求都是新对象，供 MessageList 一次性响应
   recommendReveal: { id: string } | null;
+  // 当前正在语音播放的消息 ID 全局同时只播一条
+  playingMessageId: string | null;
   fetchSessions: () => Promise<void>;
   createSession: () => Promise<string>;
   deleteSession: (sessionId: string) => Promise<void>;
@@ -107,6 +110,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   cancelRequested: false,
   openedSourceMessageId: null,
   recommendReveal: null,
+  playingMessageId: null,
   fetchSessions: async () => {
     set({ isLoading: true });
     try {
@@ -144,6 +148,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     if (state.isStreaming) {
       get().cancelGeneration();
     }
+    // 切换会话时停止语音播放
+    stopVoicePlayback();
     set({
       currentSessionId: null,
       messages: [],
@@ -163,6 +169,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   deleteSession: async (sessionId) => {
     try {
       await deleteSessionRequest(sessionId);
+      // 删除当前会话时停止语音播放
+      if (get().currentSessionId === sessionId) {
+        stopVoicePlayback();
+      }
       set((state) => ({
         sessions: state.sessions.filter((session) => session.id !== sessionId),
         messages: state.currentSessionId === sessionId ? [] : state.messages,
@@ -196,6 +206,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
     if (get().isStreaming) {
       get().cancelGeneration();
     }
+    // 切换会话时停止语音播放
+    stopVoicePlayback();
     set({
       isLoading: true,
       currentSessionId: sessionId,

--- a/infra-ai/pom.xml
+++ b/infra-ai/pom.xml
@@ -21,5 +21,10 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-jvm</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
@@ -72,6 +72,11 @@ public class AIModelProperties {
     private Stream stream = new Stream();
 
     /**
+     * WebSocket 连接及任务生命周期配置
+     */
+    private WebSocketConfig websocket = new WebSocketConfig();
+
+    /**
      * 模型组配置类
      * 包含默认模型与候选模型列表
      */
@@ -106,6 +111,33 @@ public class AIModelProperties {
          * key: 档位名（如 fast/standard/deep），value: 该档位的候选与超时
          */
         private Map<String, TierConfig> tiers = new HashMap<>();
+    }
+
+    /**
+     * WebSocket 配置
+     */
+    @Data
+    public static class WebSocketConfig {
+
+        private long connectTimeoutMs;
+
+        private long taskStartTimeoutMs;
+
+        private long taskPacketIdleTimeoutMs;
+
+        private int maxTotalPerModel;
+
+        private int maxIdlePerModel;
+
+        /**
+         * 连接空闲驱逐超时 0 表示不驱逐
+         */
+        private long idleTimeoutMs;
+
+        /**
+         * 空闲驱逐扫描间隔
+         */
+        private long evictionIntervalMs;
     }
 
     /**

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
@@ -62,6 +62,11 @@ public class AIModelProperties {
     private ModelGroup vlm = new ModelGroup();
 
     /**
+     * 语音合成模型组配置
+     */
+    private ModelGroup tts = new ModelGroup();
+
+    /**
      * 模型选择策略配置
      */
     private Selection selection = new Selection();
@@ -93,6 +98,11 @@ public class AIModelProperties {
          * chat 组下退化为"物理模型注册表"：只登记 id→provider/model，档位排序由 tiers 决定
          */
         private List<ModelCandidate> candidates = new ArrayList<>();
+
+        /**
+         * 模型组调用超时预算
+         */
+        private Long timeoutMs;
 
         /**
          * 默认档位名（仅 chat 使用）
@@ -205,6 +215,11 @@ public class AIModelProperties {
          * 是否支持思考链功能
          */
         private Boolean supportsThinking = false;
+
+        /**
+         * 语音类模型默认音色
+         */
+        private String voice;
     }
 
     /**
@@ -223,6 +238,11 @@ public class AIModelProperties {
          * API 密钥
          */
         private String apiKey;
+
+        /**
+         * 供应商工作空间标识
+         */
+        private String workspace;
 
         /**
          * 端点映射配置

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelSelector.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelSelector.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
  * 负责根据配置和当前需求选择合适的模型候选列表
  * <p>
  * chat 组走档位机制：任务 → 档位（tier）→ 档位内有序候选；
- * embedding/rerank/vlm 组走 defaultModel + priority 的传统排序
+ * embedding/rerank/vlm/tts 组走 defaultModel + priority 的传统排序
  */
 @Slf4j
 @Component
@@ -94,6 +94,10 @@ public class ModelSelector {
 
     public List<ModelTarget> selectVlmCandidates() {
         return selectCandidates(properties.getVlm());
+    }
+
+    public List<ModelTarget> selectTtsCandidates() {
+        return selectCandidates(properties.getTts());
     }
 
     // ==================== chat：档位机制 ====================
@@ -183,7 +187,7 @@ public class ModelSelector {
         return registry;
     }
 
-    // ==================== embedding/rerank/vlm：defaultModel + priority ====================
+    // ==================== embedding/rerank/vlm/tts：defaultModel + priority ====================
 
     private List<ModelTarget> selectCandidates(AIModelProperties.ModelGroup group) {
         if (group == null || group.getCandidates() == null) {
@@ -191,7 +195,7 @@ public class ModelSelector {
         }
         List<AIModelProperties.ModelCandidate> orderedCandidates =
                 filterAndSortCandidates(group.getCandidates(), group.getDefaultModel());
-        return buildAvailableTargets(orderedCandidates);
+        return buildAvailableTargets(orderedCandidates, group.getTimeoutMs());
     }
 
     /**
@@ -211,12 +215,13 @@ public class ModelSelector {
                 .collect(Collectors.toList());
     }
 
-    private List<ModelTarget> buildAvailableTargets(List<AIModelProperties.ModelCandidate> candidates) {
+    private List<ModelTarget> buildAvailableTargets(List<AIModelProperties.ModelCandidate> candidates,
+                                                    Long timeoutMs) {
         Map<String, AIModelProperties.ProviderConfig> providers = properties.getProviders();
 
-        // embedding/rerank/vlm 无档位预算，超时走 HTTP 客户端默认
+        // embedding/rerank/vlm 未配置 timeoutMs 时走 HTTP 客户端默认；TTS 的 timeoutMs 用于首包等待
         return candidates.stream()
-                .map(candidate -> buildModelTarget(candidate, providers, null))
+                .map(candidate -> buildModelTarget(candidate, providers, timeoutMs))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelTarget.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelTarget.java
@@ -27,7 +27,7 @@ import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
  * @param id        模型唯一标识符
  * @param candidate 模型候选配置，包含模型的具体参数和设置
  * @param provider  提供商配置，包含模型提供商的相关信息
- * @param timeoutMs 本次调用的超时预算（毫秒），来自命中的档位配置；null 表示不额外限制，走 HTTP 客户端默认
+ * @param timeoutMs 本次调用的超时预算
  */
 public record ModelTarget(
         String id,

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/AbstractWebSocketTtsClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/AbstractWebSocketTtsClient.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import com.nageoffer.ai.ragent.infra.voice.websocket.VoiceConnection;
+import com.nageoffer.ai.ragent.infra.voice.websocket.VoiceStreamCallback;
+import com.nageoffer.ai.ragent.infra.voice.websocket.WebSocketTaskExecutor;
+import com.nageoffer.ai.ragent.infra.voice.websocket.WebSocketTaskSession;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 基于 WebSocket 的 TTS 客户端模板
+ */
+public abstract class AbstractWebSocketTtsClient<P, C extends VoiceConnection<P, String, byte[]>>
+        implements TtsClient, AutoCloseable {
+
+    /**
+     * continue-task 单次发送的文本长度上限
+     */
+    private static final int CHUNK_MAX_LEN = 80;
+
+    private final WebSocketTaskExecutor<P, String, byte[], C> taskExecutor;
+
+    protected AbstractWebSocketTtsClient(Executor executor, AIModelProperties.WebSocketConfig poolConfig) {
+        this.taskExecutor = new WebSocketTaskExecutor<>(this::createConnection, poolConfig, executor);
+    }
+
+    @Override
+    public final StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target) {
+        AtomicBoolean audioReceived = new AtomicBoolean();
+        VoiceStreamCallback<byte[]> streamCallback = adaptCallback(callback, audioReceived);
+        WebSocketTaskSession<String> session = taskExecutor.openTask(
+                target,
+                buildTaskParam(target),
+                streamCallback,
+                () -> !audioReceived.get()
+        );
+        try {
+            // 按协议限制分块发送
+            for (String chunk : splitChunks(text)) {
+                session.send(chunk);
+            }
+            session.finish().whenComplete((ignored, throwable) -> {
+                if (throwable != null) {
+                    streamCallback.onError(throwable);
+                }
+            });
+            return session::cancel;
+        } catch (RuntimeException exception) {
+            session.cancel();
+            throw exception;
+        }
+    }
+
+    /**
+     * 按长度上限分块
+     */
+    private List<String> splitChunks(String text) {
+        List<String> chunks = new ArrayList<>();
+        for (int start = 0; start < text.length(); start += CHUNK_MAX_LEN) {
+            String chunk = text.substring(start, Math.min(start + CHUNK_MAX_LEN, text.length()));
+            if (!chunk.isBlank()) {
+                chunks.add(chunk);
+            }
+        }
+        return chunks;
+    }
+
+    protected abstract P buildTaskParam(ModelTarget target);
+
+    protected abstract C createConnection(ModelTarget target);
+
+    private VoiceStreamCallback<byte[]> adaptCallback(TtsCallback callback,
+                                                       AtomicBoolean audioReceived) {
+        return new VoiceStreamCallback<>() {
+            @Override
+            protected void onValidPacket(byte[] packet) {
+                if (packet.length > 0) {
+                    audioReceived.set(true);
+                }
+                callback.onAudio(packet);
+            }
+
+            @Override
+            protected void onTaskComplete() {
+                callback.onComplete();
+            }
+
+            @Override
+            protected void onTaskError(Throwable throwable) {
+                callback.onError(throwable);
+            }
+        };
+    }
+
+    @Override
+    public final void close() {
+        taskExecutor.close();
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/BaiLianTtsClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/BaiLianTtsClient.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.enums.ModelCapability;
+import com.nageoffer.ai.ragent.infra.enums.ModelProvider;
+import com.nageoffer.ai.ragent.infra.http.HttpResponseHelper;
+import com.nageoffer.ai.ragent.infra.http.ModelClientErrorType;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.http.ModelUrlResolver;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import com.nageoffer.ai.ragent.infra.voice.websocket.VoiceConnection;
+import jakarta.annotation.PreDestroy;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+import okio.ByteString;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 阿里云百炼 CosyVoice TTS 客户端
+ */
+@Component
+public class BaiLianTtsClient extends AbstractWebSocketTtsClient<
+        BaiLianTtsClient.BaiLianTtsTaskParam,
+        BaiLianTtsClient.BaiLianTtsConnection> {
+
+    private final WebSocket.Factory webSocketFactory;
+    private final AIModelProperties.WebSocketConfig websocketConfig;
+
+    public BaiLianTtsClient(@Qualifier("streamingHttpClient") WebSocket.Factory webSocketFactory,
+                            @Qualifier("webSocketLifecycleExecutor") Executor taskExecutor,
+                            AIModelProperties properties) {
+        super(taskExecutor, properties.getWebsocket());
+        this.webSocketFactory = webSocketFactory;
+        this.websocketConfig = properties.getWebsocket();
+    }
+
+    @Override
+    public String provider() {
+        return ModelProvider.BAI_LIAN.getId();
+    }
+
+    @Override
+    protected BaiLianTtsConnection createConnection(ModelTarget target) {
+        return new BaiLianTtsConnection(target, webSocketFactory, websocketConfig);
+    }
+
+    @Override
+    protected BaiLianTtsTaskParam buildTaskParam(ModelTarget target) {
+        return new BaiLianTtsTaskParam(
+                HttpResponseHelper.requireModel(target, "TTS"),
+                requireVoice(target)
+        );
+    }
+
+    /**
+     * 获取候选模型配置的音色
+     */
+    private String requireVoice(ModelTarget target) {
+        String voice = target.candidate().getVoice();
+        if (voice == null || voice.isBlank()) {
+            throw new ModelClientException("TTS 未配置默认音色，modelId=" + target.id(),
+                    ModelClientErrorType.CLIENT_ERROR, null);
+        }
+        return voice;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        close();
+    }
+
+    record BaiLianTtsTaskParam(
+            String model,
+            String voice
+    ) {
+    }
+
+    static final class BaiLianTtsConnection
+            extends VoiceConnection<BaiLianTtsTaskParam, String, byte[]> {
+
+        private final Gson gson = new Gson();
+
+        private BaiLianTtsConnection(ModelTarget target,
+                                     WebSocket.Factory webSocketFactory,
+                                     AIModelProperties.WebSocketConfig websocketConfig) {
+            super(target, webSocketFactory, websocketConfig);
+        }
+
+        @Override
+        protected Request buildWebSocketRequest() {
+            AIModelProperties.ProviderConfig provider = HttpResponseHelper.requireProvider(target(), "TTS");
+            HttpResponseHelper.requireApiKey(provider, "TTS");
+            String url = toWebSocketUrl(ModelUrlResolver.resolveUrl(provider, target().candidate(), ModelCapability.TTS));
+            Request.Builder request = new Request.Builder()
+                    .url(url)
+                    .addHeader("Authorization", "Bearer " + provider.getApiKey());
+            if (provider.getWorkspace() != null && !provider.getWorkspace().isBlank()) {
+                request.addHeader("X-DashScope-WorkSpace", provider.getWorkspace());
+            }
+            return request.build();
+        }
+
+        @Override
+        protected void doStartTask(String taskId, BaiLianTtsTaskParam param) {
+            JsonObject parameters = new JsonObject();
+            parameters.addProperty("text_type", "PlainText");
+            parameters.addProperty("voice", param.voice());
+            parameters.addProperty("format", "mp3");
+
+            JsonObject payload = new JsonObject();
+            payload.addProperty("task_group", "audio");
+            payload.addProperty("task", "tts");
+            payload.addProperty("function", "SpeechSynthesizer");
+            payload.addProperty("model", param.model());
+            payload.add("parameters", parameters);
+            payload.add("input", new JsonObject());
+
+            sendJson(command("run-task", taskId, payload));
+        }
+
+        @Override
+        protected void doSend(String taskId, String text) {
+            JsonObject input = new JsonObject();
+            input.addProperty("text", text);
+            JsonObject payload = new JsonObject();
+            payload.add("input", input);
+            sendJson(command("continue-task", taskId, payload));
+        }
+
+        @Override
+        protected void doFinishTask(String taskId) {
+            JsonObject payload = new JsonObject();
+            payload.add("input", new JsonObject());
+            sendJson(command("finish-task", taskId, payload));
+        }
+
+        @Override
+        protected void doCancelTask(String taskId) {
+            JsonObject input = new JsonObject();
+            input.addProperty("directive", "cancel");
+            JsonObject payload = new JsonObject();
+            payload.add("input", input);
+            sendJson(command("finish-task", taskId, payload));
+        }
+
+        private JsonObject command(String action, String taskId, JsonObject payload) {
+            JsonObject header = new JsonObject();
+            header.addProperty("action", action);
+            header.addProperty("task_id", taskId);
+            header.addProperty("streaming", "duplex");
+
+            JsonObject command = new JsonObject();
+            command.add("header", header);
+            command.add("payload", payload);
+            return command;
+        }
+
+        private void sendJson(JsonObject message) {
+            WebSocket current = webSocket();
+            if (!current.send(gson.toJson(message))) {
+                throw new ModelClientException("TTS WebSocket 发送失败，modelId=" + modelId(),
+                        ModelClientErrorType.NETWORK_ERROR, null);
+            }
+        }
+
+        @Override
+        protected void handleTextMessage(String text) {
+            JsonObject response = gson.fromJson(text, JsonObject.class);
+            JsonObject header = response.getAsJsonObject("header");
+            if (header == null || !header.has("event")) {
+                return;
+            }
+            String responseTaskId = header.has("task_id") ? header.get("task_id").getAsString() : null;
+            validateResponseTaskId(responseTaskId);
+            String event = header.get("event").getAsString();
+            switch (event) {
+                case "task-started" -> markTaskStarted();
+                case "task-finished" -> markTaskFinished();
+                case "task-failed" -> failTask(header);
+                default -> {
+                    // 忽略无需处理的元信息事件
+                }
+            }
+        }
+
+        @Override
+        protected byte[] decodeBinaryMessage(ByteString bytes) {
+            return bytes.toByteArray();
+        }
+
+        private void failTask(JsonObject header) {
+            String errorCode = header.has("error_code") ? header.get("error_code").getAsString() : "unknown";
+            String errorMessage = header.has("error_message") ? header.get("error_message").getAsString() : "unknown";
+            markTaskFailed(new ModelClientException(
+                    "TTS 任务失败，modelId=" + modelId() + ": " + errorCode + " - " + errorMessage,
+                    ModelClientErrorType.SERVER_ERROR,
+                    null
+            ));
+        }
+
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/BinaryProbeStreamBridge.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/BinaryProbeStreamBridge.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * 音频流首包探测桥接器
+ */
+final class BinaryProbeStreamBridge implements TtsCallback {
+
+    private enum Disposition {
+        PENDING,
+        COMMITTED,
+        DISCARDED
+    }
+
+    private final TtsCallback downstream;
+    private final CompletableFuture<ProbeResult> probe = new CompletableFuture<>();
+    private final Object lock = new Object();
+    private final List<Runnable> buffer = new ArrayList<>();
+    private Disposition disposition = Disposition.PENDING;
+    private boolean terminated;
+
+    BinaryProbeStreamBridge(TtsCallback downstream) {
+        this.downstream = downstream;
+    }
+
+    @Override
+    public void onAudio(byte[] audio) {
+        if (audio.length == 0) {
+            return;
+        }
+        accept(ProbeResult.success(), false, () -> downstream.onAudio(audio));
+    }
+
+    @Override
+    public void onComplete() {
+        accept(ProbeResult.noContent(), true, downstream::onComplete);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        accept(ProbeResult.error(throwable), true, () -> downstream.onError(throwable));
+    }
+
+    ProbeResult awaitFirstAudio(long timeout, TimeUnit unit) throws InterruptedException {
+        try {
+            return probe.get(timeout, unit);
+        } catch (TimeoutException exception) {
+            return ProbeResult.timeout();
+        } catch (ExecutionException exception) {
+            return ProbeResult.error(exception.getCause());
+        }
+    }
+
+    void commit() {
+        synchronized (lock) {
+            disposition = Disposition.COMMITTED;
+            buffer.forEach(Runnable::run);
+            buffer.clear();
+        }
+    }
+
+    void discard() {
+        synchronized (lock) {
+            disposition = Disposition.DISCARDED;
+            buffer.clear();
+        }
+    }
+
+    private void accept(ProbeResult result, boolean terminal, Runnable action) {
+        synchronized (lock) {
+            if (terminated || disposition == Disposition.DISCARDED) {
+                return;
+            }
+            terminated = terminal;
+            probe.complete(result);
+            if (disposition == Disposition.PENDING) {
+                buffer.add(action);
+                return;
+            }
+            action.run();
+        }
+    }
+
+    static final class ProbeResult {
+
+        enum Type {
+            SUCCESS,
+            ERROR,
+            TIMEOUT,
+            NO_CONTENT
+        }
+
+        private final Type type;
+        private final Throwable error;
+
+        private ProbeResult(Type type, Throwable error) {
+            this.type = type;
+            this.error = error;
+        }
+
+        Type getType() {
+            return type;
+        }
+
+        Throwable getError() {
+            return error;
+        }
+
+        boolean isSuccess() {
+            return type == Type.SUCCESS;
+        }
+
+        private static ProbeResult success() {
+            return new ProbeResult(Type.SUCCESS, null);
+        }
+
+        private static ProbeResult error(Throwable throwable) {
+            return new ProbeResult(Type.ERROR, throwable);
+        }
+
+        private static ProbeResult timeout() {
+            return new ProbeResult(Type.TIMEOUT, null);
+        }
+
+        private static ProbeResult noContent() {
+            return new ProbeResult(Type.NO_CONTENT, null);
+        }
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/RoutingTtsService.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/RoutingTtsService.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import com.nageoffer.ai.ragent.framework.errorcode.BaseErrorCode;
+import com.nageoffer.ai.ragent.framework.exception.RemoteException;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.http.ModelClientErrorType;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.model.ModelHealthStore;
+import com.nageoffer.ai.ragent.infra.model.ModelSelector;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * TTS 模型路由服务
+ */
+@Slf4j
+@Service
+@Primary
+public class RoutingTtsService implements TtsService {
+
+    private static final String STREAM_FAILED_MESSAGE = "TTS 流式任务失败";
+    private static final String STREAM_TIMEOUT_MESSAGE = "TTS 首音频超时";
+    private static final String STREAM_NO_CONTENT_MESSAGE = "TTS 未返回有效音频";
+
+    private final ModelSelector selector;
+    private final ModelHealthStore healthStore;
+    private final Map<String, TtsClient> clientsByProvider;
+
+    public RoutingTtsService(ModelSelector selector,
+                             ModelHealthStore healthStore,
+                             List<TtsClient> clients) {
+        this.selector = selector;
+        this.healthStore = healthStore;
+        this.clientsByProvider = clients.stream()
+                .collect(Collectors.toMap(TtsClient::provider, Function.identity()));
+    }
+
+    @Override
+    public StreamCancellationHandle synthesize(String text, TtsCallback callback, TtsTaskObserver taskObserver) {
+        List<ModelTarget> targets = selector.selectTtsCandidates();
+        if (targets.isEmpty()) {
+            throw notifyAllFailed(callback, null);
+        }
+
+        Throwable lastError = null;
+        for (ModelTarget target : targets) {
+            TtsClient client = resolveClient(target);
+            if (client == null) {
+                lastError = new ModelClientException(
+                        "TTS 提供商客户端缺失，provider=" + target.candidate().getProvider()
+                                + "，modelId=" + target.id(),
+                        ModelClientErrorType.CLIENT_ERROR,
+                        null
+                );
+                continue;
+            }
+            ModelHealthStore.CallPermit permit = healthStore.allowCall(target.id());
+            if (permit == null) {
+                continue;
+            }
+
+            try {
+                BinaryProbeStreamBridge bridge = new BinaryProbeStreamBridge(callback);
+                StreamCancellationHandle handle;
+                try {
+                    handle = client.synthesize(text, bridge, target);
+                } catch (RuntimeException exception) {
+                    bridge.discard();
+                    lastError = exception;
+                    if (exception instanceof ModelClientException clientException
+                            && clientException.getErrorType() == ModelClientErrorType.RATE_LIMITED) {
+                        log.warn("TTS 暂无可用调用容量，modelId={}", target.id());
+                        continue;
+                    }
+                    healthStore.markFailure(target.id());
+                    log.warn("TTS 任务启动失败，modelId={}，provider={}",
+                            target.id(), target.candidate().getProvider(), exception);
+                    continue;
+                }
+
+                taskObserver.onTaskStarted(handle);
+                if (taskObserver.isCancelled()) {
+                    bridge.discard();
+                    return handle;
+                }
+
+                BinaryProbeStreamBridge.ProbeResult result = awaitFirstAudio(bridge, handle, target);
+                if (taskObserver.isCancelled()) {
+                    bridge.discard();
+                    return handle;
+                }
+                if (result.isSuccess()) {
+                    healthStore.markSuccess(target.id());
+                    bridge.commit();
+                    return handle;
+                }
+
+                bridge.discard();
+                healthStore.markFailure(target.id());
+                cancelQuietly(handle, target);
+                lastError = buildLastErrorAndLog(result, target);
+            } finally {
+                // 归还半开探测名额
+                healthStore.releaseHalfOpenPermit(permit);
+            }
+        }
+
+        throw notifyAllFailed(callback, lastError);
+    }
+
+    private TtsClient resolveClient(ModelTarget target) {
+        TtsClient client = clientsByProvider.get(target.candidate().getProvider());
+        if (client == null) {
+            log.warn("TTS 提供商客户端缺失: provider={}，modelId={}",
+                    target.candidate().getProvider(), target.id());
+        }
+        return client;
+    }
+
+    private BinaryProbeStreamBridge.ProbeResult awaitFirstAudio(BinaryProbeStreamBridge bridge,
+                                                                StreamCancellationHandle handle,
+                                                                ModelTarget target) {
+        try {
+            long timeoutMs = target.timeoutMs();
+            return bridge.awaitFirstAudio(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            RemoteException interrupted = new RemoteException(
+                    "TTS 首音频等待被中断", exception, BaseErrorCode.REMOTE_ERROR);
+            bridge.onError(interrupted);
+            bridge.commit();
+            cancelQuietly(handle, target);
+            throw interrupted;
+        }
+    }
+
+    private Throwable buildLastErrorAndLog(BinaryProbeStreamBridge.ProbeResult result, ModelTarget target) {
+        String provider = target.candidate().getProvider();
+        switch (result.getType()) {
+            case ERROR -> {
+                Throwable error = result.getError() != null
+                        ? result.getError()
+                        : new ModelClientException(STREAM_FAILED_MESSAGE, ModelClientErrorType.SERVER_ERROR, null);
+                log.warn("TTS 失败模型: modelId={}，provider={}，原因: 流式任务失败，切换下一个模型",
+                        target.id(), provider, error);
+                return error;
+            }
+            case TIMEOUT -> {
+                ModelClientException timeout = new ModelClientException(
+                        STREAM_TIMEOUT_MESSAGE, ModelClientErrorType.NETWORK_ERROR, null);
+                log.warn("TTS 失败模型: modelId={}，provider={}，原因: 首音频超时，切换下一个模型",
+                        target.id(), provider);
+                return timeout;
+            }
+            case NO_CONTENT -> {
+                ModelClientException noContent = new ModelClientException(
+                        STREAM_NO_CONTENT_MESSAGE, ModelClientErrorType.INVALID_RESPONSE, null);
+                log.warn("TTS 失败模型: modelId={}，provider={}，原因: 未返回有效音频，切换下一个模型",
+                        target.id(), provider);
+                return noContent;
+            }
+            default -> {
+                ModelClientException unknown = new ModelClientException(
+                        STREAM_FAILED_MESSAGE, ModelClientErrorType.SERVER_ERROR, null);
+                log.warn("TTS 失败模型: modelId={}，provider={}，原因: 流式任务失败（未知类型），切换下一个模型",
+                        target.id(), provider);
+                return unknown;
+            }
+        }
+    }
+
+    private RuntimeException notifyAllFailed(TtsCallback callback, Throwable lastError) {
+        RemoteException failure = new RemoteException(
+                "所有 TTS 模型均调用失败",
+                lastError,
+                BaseErrorCode.REMOTE_ERROR
+        );
+        callback.onError(failure);
+        return failure;
+    }
+
+    private void cancelQuietly(StreamCancellationHandle handle, ModelTarget target) {
+        try {
+            handle.cancel();
+        } catch (RuntimeException exception) {
+            log.warn("TTS 失败候选取消异常，modelId={}，provider={}",
+                    target.id(), target.candidate().getProvider(), exception);
+        }
+    }
+
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsCallback.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsCallback.java
@@ -15,45 +15,16 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.infra.enums;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+package com.nageoffer.ai.ragent.infra.voice.tts;
 
 /**
- * 模型能力枚举类
- * 定义了AI模型支持的各种能力类型
+ * TTS 流式回调
  */
-@Getter
-@RequiredArgsConstructor
-public enum ModelCapability {
+public interface TtsCallback {
 
-    /**
-     * 聊天对话能力
-     * 支持与用户进行自然语言对话交互
-     */
-    CHAT("Chat"),
+    void onAudio(byte[] audio);
 
-    /**
-     * 向量嵌入能力
-     * 将文本转换为向量表示，用于语义搜索和相似度计算
-     */
-    EMBEDDING("Embedding"),
+    void onComplete();
 
-    /**
-     * 重排序能力
-     * 对搜索结果进行重新排序，提高相关性
-     */
-    RERANK("Rerank"),
-
-    /**
-     * 文本转语音能力
-     */
-    TTS("TTS");
-
-
-    /**
-     * 能力的显示名称
-     */
-    private final String displayName;
+    void onError(Throwable throwable);
 }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsClient.java
@@ -15,45 +15,17 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.infra.enums;
+package com.nageoffer.ai.ragent.infra.voice.tts;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
 
 /**
- * 模型能力枚举类
- * 定义了AI模型支持的各种能力类型
+ * TTS 客户端接口
  */
-@Getter
-@RequiredArgsConstructor
-public enum ModelCapability {
+public interface TtsClient {
 
-    /**
-     * 聊天对话能力
-     * 支持与用户进行自然语言对话交互
-     */
-    CHAT("Chat"),
+    String provider();
 
-    /**
-     * 向量嵌入能力
-     * 将文本转换为向量表示，用于语义搜索和相似度计算
-     */
-    EMBEDDING("Embedding"),
-
-    /**
-     * 重排序能力
-     * 对搜索结果进行重新排序，提高相关性
-     */
-    RERANK("Rerank"),
-
-    /**
-     * 文本转语音能力
-     */
-    TTS("TTS");
-
-
-    /**
-     * 能力的显示名称
-     */
-    private final String displayName;
+    StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target);
 }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsService.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsService.java
@@ -15,45 +15,19 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.infra.enums;
+package com.nageoffer.ai.ragent.infra.voice.tts;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
 
 /**
- * 模型能力枚举类
- * 定义了AI模型支持的各种能力类型
+ * 文本转语音服务
  */
-@Getter
-@RequiredArgsConstructor
-public enum ModelCapability {
+public interface TtsService {
 
-    /**
-     * 聊天对话能力
-     * 支持与用户进行自然语言对话交互
-     */
-    CHAT("Chat"),
+    default StreamCancellationHandle synthesize(String text, TtsCallback callback) {
+        return synthesize(text, callback, handle -> {
+        });
+    }
 
-    /**
-     * 向量嵌入能力
-     * 将文本转换为向量表示，用于语义搜索和相似度计算
-     */
-    EMBEDDING("Embedding"),
-
-    /**
-     * 重排序能力
-     * 对搜索结果进行重新排序，提高相关性
-     */
-    RERANK("Rerank"),
-
-    /**
-     * 文本转语音能力
-     */
-    TTS("TTS");
-
-
-    /**
-     * 能力的显示名称
-     */
-    private final String displayName;
+    StreamCancellationHandle synthesize(String text, TtsCallback callback, TtsTaskObserver taskObserver);
 }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsTaskObserver.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/tts/TtsTaskObserver.java
@@ -15,45 +15,25 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.infra.enums;
+package com.nageoffer.ai.ragent.infra.voice.tts;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
 
 /**
- * 模型能力枚举类
- * 定义了AI模型支持的各种能力类型
+ * TTS 任务生命周期观察器
  */
-@Getter
-@RequiredArgsConstructor
-public enum ModelCapability {
+@FunctionalInterface
+public interface TtsTaskObserver {
 
     /**
-     * 聊天对话能力
-     * 支持与用户进行自然语言对话交互
+     * 供应商任务已启动
      */
-    CHAT("Chat"),
+    void onTaskStarted(StreamCancellationHandle handle);
 
     /**
-     * 向量嵌入能力
-     * 将文本转换为向量表示，用于语义搜索和相似度计算
+     * 当前调用是否已取消
      */
-    EMBEDDING("Embedding"),
-
-    /**
-     * 重排序能力
-     * 对搜索结果进行重新排序，提高相关性
-     */
-    RERANK("Rerank"),
-
-    /**
-     * 文本转语音能力
-     */
-    TTS("TTS");
-
-
-    /**
-     * 能力的显示名称
-     */
-    private final String displayName;
+    default boolean isCancelled() {
+        return false;
+    }
 }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceConnection.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceConnection.java
@@ -1,0 +1,520 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.http.ModelClientErrorType;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 可复用 Voice WebSocket 连接模板
+ */
+public abstract class VoiceConnection<P, I, O> implements AutoCloseable {
+
+    private final ModelTarget target;
+    private final WebSocket.Factory webSocketFactory;
+    private final AIModelProperties.WebSocketConfig webSocketConfig;
+    private final AtomicReference<VoiceConnectionState> state = new AtomicReference<>(VoiceConnectionState.CONNECTING);
+    private final AtomicReference<String> currentTaskId = new AtomicReference<>();
+    private final AtomicReference<VoiceStreamCallback<O>> currentCallback = new AtomicReference<>();
+    private final AtomicBoolean cancelling = new AtomicBoolean();
+    private final CompletableFuture<Void> connectionReady = new CompletableFuture<>();
+    private volatile CompletableFuture<Void> taskStarted;
+    private volatile CompletableFuture<Void> taskFinished;
+    private final AtomicReference<CompletableFuture<Void>> packetReceivedSignal = new AtomicReference<>();
+    private volatile long lastPacketReceivedMs;
+    private volatile WebSocket webSocket;
+
+    protected VoiceConnection(ModelTarget target,
+                              WebSocket.Factory webSocketFactory,
+                              AIModelProperties.WebSocketConfig webSocketConfig) {
+        this.target = target;
+        this.webSocketFactory = webSocketFactory;
+        this.webSocketConfig = webSocketConfig;
+    }
+
+    /**
+     * 建立 WebSocket 并完成连接级初始化
+     */
+    public final void connect() {
+        try {
+            openWebSocket();
+            await(connectionReady, webSocketConfig.getConnectTimeoutMs());
+            if (!state.compareAndSet(VoiceConnectionState.CONNECTING, VoiceConnectionState.IDLE)) {
+                throw new IllegalStateException("Voice 连接在初始化期间失效，modelId=" + modelId());
+            }
+        } catch (Exception exception) {
+            markBroken();
+            throw wrap("Voice WebSocket 建连失败，modelId=" + modelId(), exception);
+        }
+    }
+
+    /**
+     * 在当前空闲连接上启动任务
+     */
+    public final void startTask(String taskId, P param, VoiceStreamCallback<O> callback) {
+        if (!state.compareAndSet(VoiceConnectionState.IDLE, VoiceConnectionState.TASK_STARTING)) {
+            throw new IllegalStateException("Voice 连接当前不可启动任务，modelId=" + modelId() + "，state=" + state.get());
+        }
+        currentTaskId.set(taskId);
+        currentCallback.set(callback);
+        taskStarted = new CompletableFuture<>();
+        taskFinished = new CompletableFuture<>();
+        packetReceivedSignal.set(new CompletableFuture<>());
+        lastPacketReceivedMs = 0L;
+        try {
+            doStartTask(taskId, param);
+            await(taskStarted, webSocketConfig.getTaskStartTimeoutMs());
+            if (!state.compareAndSet(VoiceConnectionState.TASK_STARTING, VoiceConnectionState.TASK_RUNNING)) {
+                throw new IllegalStateException("Voice 任务启动期间连接失效，modelId=" + modelId() + "，taskId=" + taskId);
+            }
+        } catch (Exception exception) {
+            RuntimeException failure = wrap("Voice 任务启动失败，modelId=" + modelId() + "，taskId=" + taskId,
+                    exception);
+            markBrokenAndNotify(failure);
+            throw failure;
+        }
+    }
+
+    /**
+     * 向当前任务发送内容
+     */
+    public final void send(String taskId, I request) {
+        requireCurrentTask(taskId, VoiceConnectionState.TASK_RUNNING);
+        try {
+            doSend(taskId, request);
+        } catch (Exception exception) {
+            RuntimeException failure = wrap("Voice 任务数据发送失败，modelId=" + modelId() + "，taskId=" + taskId,
+                    exception);
+            markBrokenAndNotify(failure);
+            throw failure;
+        }
+    }
+
+    /**
+     * 结束当前任务并等待供应商终态
+     */
+    public final void finishTask(String taskId) {
+        requireCurrentTask(taskId, VoiceConnectionState.TASK_RUNNING);
+        if (!state.compareAndSet(VoiceConnectionState.TASK_RUNNING, VoiceConnectionState.TASK_FINISHING)) {
+            throw new IllegalStateException("Voice 任务当前不可结束，modelId=" + modelId() + "，taskId=" + taskId
+                    + "，state=" + state.get());
+        }
+        try {
+            doFinishTask(taskId);
+            awaitTaskTerminated(taskId);
+            completeTask(taskId, VoiceConnectionState.TASK_FINISHING);
+        } catch (Exception exception) {
+            RuntimeException failure = wrap("Voice 任务结束失败，modelId=" + modelId() + "，taskId=" + taskId,
+                    exception);
+            markBrokenAndNotify(failure);
+            throw failure;
+        }
+    }
+
+    /**
+     * 取消当前任务并禁用连接复用
+     */
+    public final void cancelTask(String taskId) {
+        if (state.get() == VoiceConnectionState.IDLE && currentTaskId.get() == null) {
+            return;
+        }
+        requireCurrentTask(taskId, VoiceConnectionState.TASK_RUNNING, VoiceConnectionState.TASK_FINISHING,
+                VoiceConnectionState.TASK_CANCELLING);
+        VoiceConnectionState previous = state.getAndUpdate(current -> switch (current) {
+            case TASK_RUNNING, TASK_FINISHING -> VoiceConnectionState.TASK_CANCELLING;
+            default -> current;
+        });
+        if (previous != VoiceConnectionState.TASK_RUNNING
+                && previous != VoiceConnectionState.TASK_FINISHING
+                && previous != VoiceConnectionState.TASK_CANCELLING) {
+            throw new IllegalStateException("Voice 任务当前不可取消，modelId=" + modelId() + "，taskId=" + taskId
+                    + "，state=" + previous);
+        }
+        cancelling.set(true);
+        try {
+            if (previous != VoiceConnectionState.TASK_CANCELLING) {
+                doCancelTask(taskId);
+            }
+            awaitTaskTerminated(taskId);
+            completeTask(taskId, VoiceConnectionState.TASK_CANCELLING);
+        } catch (Exception exception) {
+            markBroken();
+            throw wrap("Voice 任务取消失败，modelId=" + modelId() + "，taskId=" + taskId, exception);
+        } finally {
+            cancelling.set(false);
+        }
+    }
+
+    public final String modelId() {
+        return target.id();
+    }
+
+    public final ModelTarget target() {
+        return target;
+    }
+
+    public final boolean isReusable() {
+        return state.get() == VoiceConnectionState.IDLE;
+    }
+
+    /**
+     * 处理物理连接异常
+     */
+    private void connectionBroken(Throwable cause) {
+        if (markBroken()) {
+            notifyTaskError(cause);
+        }
+    }
+
+    @Override
+    public final void close() {
+        VoiceConnectionState previous = state.getAndSet(VoiceConnectionState.CLOSED);
+        if (previous == VoiceConnectionState.CLOSED) {
+            return;
+        }
+        resetTaskContext();
+        try {
+            closeWebSocket();
+        } catch (Exception exception) {
+            throw wrap("Voice WebSocket 关闭失败，modelId=" + modelId(), exception);
+        } finally {
+            webSocket = null;
+        }
+    }
+
+    /**
+     * 构建供应商连接请求
+     */
+    protected abstract Request buildWebSocketRequest() throws Exception;
+
+    protected final WebSocket webSocket() {
+        return webSocket;
+    }
+
+    protected final String toWebSocketUrl(String url) {
+        if (url.startsWith("https://")) {
+            return "wss://" + url.substring("https://".length());
+        }
+        if (url.startsWith("http://")) {
+            return "ws://" + url.substring("http://".length());
+        }
+        return url;
+    }
+
+    protected abstract void doStartTask(String taskId, P param) throws Exception;
+
+    protected abstract void doSend(String taskId, I request) throws Exception;
+
+    protected abstract void doFinishTask(String taskId) throws Exception;
+
+    protected abstract void doCancelTask(String taskId) throws Exception;
+
+    /**
+     * 处理供应商文本帧
+     */
+    protected abstract void handleTextMessage(String text);
+
+    /**
+     * 将供应商二进制帧转换为业务数据包
+     */
+    protected abstract O decodeBinaryMessage(ByteString bytes);
+
+    private void openWebSocket() throws Exception {
+        Request request = buildWebSocketRequest();
+        webSocket = webSocketFactory.newWebSocket(request, new Listener());
+    }
+
+    private void closeWebSocket() {
+        WebSocket current = webSocket;
+        if (current != null && !current.close(1000, "normal")) {
+            current.cancel();
+        }
+    }
+
+    /**
+     * 校验供应商事件是否属于当前任务
+     */
+    protected final void validateResponseTaskId(String responseTaskId) {
+        String expectedTaskId = currentTaskId.get();
+        if (!Objects.equals(expectedTaskId, responseTaskId)) {
+            throw new ModelClientException(
+                    "Voice WebSocket 响应 taskId 不一致，expected=" + expectedTaskId + "，actual=" + responseTaskId,
+                    ModelClientErrorType.INVALID_RESPONSE,
+                    null
+            );
+        }
+    }
+
+    /**
+     * 标记供应商任务已启动
+     */
+    protected final void markTaskStarted() {
+        CompletableFuture<Void> started = taskStarted;
+        if (started != null) {
+            started.complete(null);
+        }
+    }
+
+    /**
+     * 标记供应商任务已正常结束
+     */
+    protected final void markTaskFinished() {
+        VoiceStreamCallback<O> callback = currentCallback.get();
+        if (callback != null) {
+            callback.onComplete();
+        }
+        completeTaskFinished(null);
+    }
+
+    /**
+     * 标记供应商任务失败
+     */
+    protected final void markTaskFailed(Throwable throwable) {
+        if (cancelling.get()) {
+            // 供应商可能用 task-failed 响应取消请求，此时不再上报业务错误
+            markBroken();
+            completeTaskFinished(null);
+            return;
+        }
+        CompletableFuture<Void> started = taskStarted;
+        if (started != null) {
+            started.completeExceptionally(throwable);
+        }
+        completeTaskFinished(throwable);
+        connectionBroken(throwable);
+    }
+
+    private void failConnection(Throwable throwable) {
+        if (cancelling.get()) {
+            // 取消可能导致连接关闭，此时不再上报业务错误
+            markBroken();
+            completeTaskFinished(null);
+            return;
+        }
+        connectionReady.completeExceptionally(throwable);
+        CompletableFuture<Void> started = taskStarted;
+        if (started != null) {
+            started.completeExceptionally(throwable);
+        }
+        completeTaskFinished(throwable);
+        connectionBroken(throwable);
+    }
+
+    private void completeTaskFinished(Throwable throwable) {
+        CompletableFuture<Void> finished = taskFinished;
+        if (finished == null) {
+            return;
+        }
+        if (throwable == null) {
+            finished.complete(null);
+        } else {
+            finished.completeExceptionally(throwable);
+        }
+    }
+
+    private void awaitTaskTerminated(String taskId) throws Exception {
+        CompletableFuture<Void> finished = taskFinished;
+        long frameIdleTimeoutMs = webSocketConfig.getTaskPacketIdleTimeoutMs();
+        Long configuredFirstPacketTimeoutMs = target.timeoutMs();
+        long firstPacketTimeoutMs = configuredFirstPacketTimeoutMs != null
+                ? configuredFirstPacketTimeoutMs
+                : frameIdleTimeoutMs;
+        long waitStartedMs = System.currentTimeMillis();
+        long firstPacketDeadline = waitStartedMs + firstPacketTimeoutMs;
+        long minimumFinishDeadline = waitStartedMs + frameIdleTimeoutMs;
+        CompletableFuture<Void> terminationSignal = finished.handle((ignored, throwable) -> null);
+        while (!finished.isDone()) {
+            CompletableFuture<Void> packetSignal = packetReceivedSignal.get();
+            long last = lastPacketReceivedMs;
+            long deadline = last > 0
+                    ? Math.max(minimumFinishDeadline, last + frameIdleTimeoutMs)
+                    : firstPacketDeadline;
+            long remainingMs = deadline - System.currentTimeMillis();
+            if (remainingMs <= 0) {
+                if (finished.isDone() || last != lastPacketReceivedMs) {
+                    continue;
+                }
+                String phase = last > 0 ? "帧间空闲" : "首帧等待";
+                throw new TimeoutException("finish-task 后" + phase + "超时，taskId=" + taskId);
+            }
+            try {
+                CompletableFuture.anyOf(terminationSignal, packetSignal)
+                        .get(remainingMs, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException ignored) {
+                // 收帧和超时可能同时发生，回到循环后按最新时间重新判断
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw interrupted;
+            } finally {
+                if (packetSignal.isDone()) {
+                    packetReceivedSignal.compareAndSet(packetSignal, new CompletableFuture<>());
+                }
+            }
+        }
+        await(finished, frameIdleTimeoutMs);
+    }
+
+    private void await(CompletableFuture<Void> future, long timeoutMs) throws Exception {
+        try {
+            future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException exception) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof Exception checkedException) {
+                throw checkedException;
+            }
+            throw new RuntimeException(cause);
+        }
+    }
+
+    private boolean markBroken() {
+        while (true) {
+            VoiceConnectionState current = state.get();
+            if (current == VoiceConnectionState.CLOSED) {
+                return false;
+            }
+            if (current == VoiceConnectionState.BROKEN
+                    || state.compareAndSet(current, VoiceConnectionState.BROKEN)) {
+                return true;
+            }
+        }
+    }
+
+    private void markBrokenAndNotify(Throwable throwable) {
+        if (markBroken()) {
+            notifyTaskError(throwable);
+        }
+    }
+
+    private void notifyTaskError(Throwable throwable) {
+        VoiceStreamCallback<O> callback = currentCallback.get();
+        if (callback != null) {
+            callback.onError(throwable);
+        }
+    }
+
+    private void completeTask(String taskId, VoiceConnectionState terminalState) {
+        // finish 和 cancel 可能并发，只有先完成状态迁移的一方负责释放租约
+        if (!Objects.equals(taskId, currentTaskId.get())) {
+            return;
+        }
+        VoiceConnectionState completedState = terminalState == VoiceConnectionState.TASK_CANCELLING
+                ? VoiceConnectionState.BROKEN
+                : VoiceConnectionState.IDLE;
+        if (!state.compareAndSet(terminalState, completedState)) {
+            return;
+        }
+        resetTaskContext();
+    }
+
+    private void resetTaskContext() {
+        taskStarted = null;
+        taskFinished = null;
+        packetReceivedSignal.set(null);
+        lastPacketReceivedMs = 0L;
+        currentTaskId.set(null);
+        currentCallback.set(null);
+    }
+
+    private void requireCurrentTask(String taskId, VoiceConnectionState... allowedStates) {
+        if (!Objects.equals(taskId, currentTaskId.get())) {
+            throw new IllegalStateException("Voice taskId 与当前任务不一致，modelId=" + modelId()
+                    + "，taskId=" + taskId + "，currentTaskId=" + currentTaskId.get());
+        }
+        VoiceConnectionState currentState = state.get();
+        for (VoiceConnectionState allowedState : allowedStates) {
+            if (currentState == allowedState) {
+                return;
+            }
+        }
+        throw new IllegalStateException("Voice 任务状态不允许当前操作，modelId=" + modelId() + "，taskId=" + taskId
+                + "，state=" + currentState);
+    }
+
+    private final class Listener extends WebSocketListener {
+
+        @Override
+        public void onOpen(WebSocket webSocket, Response response) {
+            connectionReady.complete(null);
+        }
+
+        @Override
+        public void onMessage(WebSocket webSocket, String text) {
+            try {
+                handleTextMessage(text);
+            } catch (RuntimeException exception) {
+                failConnection(exception);
+            }
+        }
+
+        @Override
+        public void onMessage(WebSocket webSocket, ByteString bytes) {
+            try {
+                lastPacketReceivedMs = System.currentTimeMillis();
+                CompletableFuture<Void> packetSignal = packetReceivedSignal.get();
+                if (packetSignal != null) {
+                    packetSignal.complete(null);
+                }
+                O packet = decodeBinaryMessage(bytes);
+                VoiceStreamCallback<O> callback = currentCallback.get();
+                if (callback != null) {
+                    callback.onPacket(packet);
+                }
+            } catch (RuntimeException exception) {
+                failConnection(exception);
+            }
+        }
+
+        @Override
+        public void onClosed(WebSocket webSocket, int code, String reason) {
+            if (state.get() != VoiceConnectionState.CLOSED) {
+                failConnection(new ModelClientException(
+                        "Voice WebSocket 已关闭: " + code + " - " + reason,
+                        ModelClientErrorType.NETWORK_ERROR,
+                        null
+                ));
+            }
+        }
+
+        @Override
+        public void onFailure(WebSocket webSocket, Throwable throwable, Response response) {
+            failConnection(throwable);
+        }
+    }
+
+    private RuntimeException wrap(String message, Exception exception) {
+        if (exception instanceof ModelClientException modelClientException) {
+            return modelClientException;
+        }
+        return new ModelClientException(message, ModelClientErrorType.NETWORK_ERROR, null, exception);
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceConnectionState.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceConnectionState.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+/**
+ * WebSocket 连接与任务状态
+ */
+public enum VoiceConnectionState {
+
+    CONNECTING,
+    IDLE,
+    TASK_STARTING,
+    TASK_RUNNING,
+    TASK_FINISHING,
+    TASK_CANCELLING,
+    BROKEN,
+    CLOSED
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceStreamCallback.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/VoiceStreamCallback.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Voice 流式回调
+ */
+public abstract class VoiceStreamCallback<E> {
+
+    private final AtomicBoolean terminated = new AtomicBoolean();
+
+    /**
+     * 接收业务数据包
+     */
+    public final void onPacket(E packet) {
+        if (terminated.get()) {
+            return;
+        }
+        onValidPacket(packet);
+    }
+
+    /**
+     * 任务正常完成
+     */
+    public final void onComplete() {
+        if (terminated.compareAndSet(false, true)) {
+            onTaskComplete();
+        }
+    }
+
+    /**
+     * 任务失败
+     */
+    public final void onError(Throwable throwable) {
+        if (terminated.compareAndSet(false, true)) {
+            onTaskError(throwable);
+        }
+    }
+
+    /**
+     * 接收有效数据包
+     */
+    protected void onValidPacket(E packet) {
+    }
+
+    /**
+     * 处理任务完成
+     */
+    protected void onTaskComplete() {
+    }
+
+    /**
+     * 处理任务失败
+     */
+    protected void onTaskError(Throwable throwable) {
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketConnectionLease.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketConnectionLease.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * WebSocket 连接租约
+ */
+@Slf4j
+public final class WebSocketConnectionLease<C extends VoiceConnection<?, ?, ?>> implements AutoCloseable {
+
+    private final GenericObjectPool<C> pool;
+    private final C connection;
+    private final AtomicBoolean invalidated = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    WebSocketConnectionLease(GenericObjectPool<C> pool, C connection) {
+        this.pool = pool;
+        this.connection = connection;
+    }
+
+    public C connection() {
+        return connection;
+    }
+
+    public void invalidate() {
+        invalidated.set(true);
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            if (!invalidated.get()) {
+                pool.returnObject(connection);
+            } else {
+                pool.invalidateObject(connection);
+            }
+        } catch (Exception exception) {
+            log.warn("Voice 连接释放失败，modelId={}", connection.modelId(), exception);
+        }
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketExecutor.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketExecutor.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import com.nageoffer.ai.ragent.framework.errorcode.BaseErrorCode;
+import com.nageoffer.ai.ragent.framework.exception.RemoteException;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.http.ModelClientErrorType;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+/**
+ * 按 modelId 管理 Voice WebSocket 连接池
+ */
+public final class WebSocketExecutor<C extends VoiceConnection<?, ?, ?>> implements AutoCloseable {
+
+    private final Function<ModelTarget, C> connectionFactory;
+    private final AIModelProperties.WebSocketConfig config;
+    private final Map<String, GenericObjectPool<C>> poolsByModelId = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public WebSocketExecutor(Function<ModelTarget, C> connectionFactory,
+                      AIModelProperties.WebSocketConfig config) {
+        this.connectionFactory = connectionFactory;
+        this.config = config;
+    }
+
+    /**
+     * 从模型连接池借用空闲 WebSocket
+     */
+    public WebSocketConnectionLease<C> acquire(ModelTarget target) {
+        if (closed.get()) {
+            throw new IllegalStateException("Voice 连接池已关闭");
+        }
+        String modelId = target.id();
+
+        GenericObjectPool<C> pool = poolsByModelId.computeIfAbsent(modelId, ignored -> createPool(target));
+        try {
+            C connection = pool.borrowObject();
+            return new WebSocketConnectionLease<>(pool, connection);
+        } catch (NoSuchElementException exception) {
+            Throwable cause = exception.getCause();
+            // Commons Pool 仅在创建连接失败时保留 cause
+            if (cause == null) {
+                throw new ModelClientException("Voice 连接池无可用连接，modelId=" + modelId,
+                        ModelClientErrorType.RATE_LIMITED, null, exception);
+            }
+            if (cause instanceof ModelClientException modelClientException) {
+                throw modelClientException;
+            }
+            throw new ModelClientException("Voice 连接创建失败，modelId=" + modelId,
+                    ModelClientErrorType.NETWORK_ERROR, null, cause);
+        } catch (Exception exception) {
+            if (exception instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new RemoteException("Voice 连接借用失败，modelId=" + modelId,
+                    exception, BaseErrorCode.REMOTE_ERROR);
+        }
+    }
+
+    private GenericObjectPool<C> createPool(ModelTarget target) {
+        GenericObjectPoolConfig<C> poolConfig = new GenericObjectPoolConfig<>();
+        poolConfig.setMaxTotal(config.getMaxTotalPerModel());
+        poolConfig.setMaxIdle(config.getMaxIdlePerModel());
+        poolConfig.setBlockWhenExhausted(false);
+        poolConfig.setTestOnBorrow(true);
+        poolConfig.setTestOnReturn(true);
+        if (config.getIdleTimeoutMs() > 0) {
+            poolConfig.setMinEvictableIdleDuration(Duration.ofMillis(config.getIdleTimeoutMs()));
+            poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(config.getEvictionIntervalMs()));
+            // -1 表示每轮检查全部空闲连接
+            poolConfig.setNumTestsPerEvictionRun(-1);
+        }
+
+        return new GenericObjectPool<>(new BasePooledObjectFactory<>() {
+            @Override
+            public C create() throws Exception {
+                C connection = connectionFactory.apply(target);
+                try {
+                    connection.connect();
+                    return connection;
+                } catch (Exception exception) {
+                    closeQuietly(connection);
+                    throw exception;
+                }
+            }
+
+            @Override
+            public PooledObject<C> wrap(C connection) {
+                return new DefaultPooledObject<>(connection);
+            }
+
+            @Override
+            public boolean validateObject(PooledObject<C> pooledObject) {
+                return pooledObject.getObject().isReusable();
+            }
+
+            @Override
+            public void destroyObject(PooledObject<C> pooledObject) {
+                closeQuietly(pooledObject.getObject());
+            }
+        }, poolConfig);
+    }
+
+    private void closeQuietly(C connection) {
+        try {
+            connection.close();
+        } catch (RuntimeException ignored) {
+            // 销毁失败不应阻塞连接池关闭
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        poolsByModelId.values().forEach(GenericObjectPool::close);
+        poolsByModelId.clear();
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketTaskExecutor.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketTaskExecutor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+
+/**
+ * WebSocket 任务执行器
+ */
+public class WebSocketTaskExecutor<P, I, O, C extends VoiceConnection<P, I, O>> implements AutoCloseable {
+
+    private final WebSocketExecutor<C> webSocketExecutor;
+    private final Executor taskExecutor;
+
+    public WebSocketTaskExecutor(Function<ModelTarget, C> connectionFactory,
+                          AIModelProperties.WebSocketConfig poolConfig,
+                          Executor taskExecutor) {
+        this.webSocketExecutor = new WebSocketExecutor<>(connectionFactory, poolConfig);
+        this.taskExecutor = taskExecutor;
+    }
+
+    public WebSocketTaskSession<I> openTask(ModelTarget target,
+                                     P taskParam,
+                                     VoiceStreamCallback<O> callback,
+                                     BooleanSupplier invalidateOnFinish) {
+        WebSocketConnectionLease<C> lease = webSocketExecutor.acquire(target);
+        String taskId = generateTaskId();
+        try {
+            lease.connection().startTask(taskId, taskParam, callback);
+            return new WebSocketTaskSession<>(taskId, lease.connection(), lease, taskExecutor, invalidateOnFinish);
+        } catch (RuntimeException exception) {
+            lease.invalidate();
+            lease.close();
+            throw exception;
+        }
+    }
+
+    protected String generateTaskId() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void close() {
+        webSocketExecutor.close();
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketTaskSession.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/voice/websocket/WebSocketTaskSession.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
+
+/**
+ * WebSocket 任务会话
+ */
+@Slf4j
+public final class WebSocketTaskSession<I> {
+
+    private enum Lifecycle {
+        ACTIVE,
+        FINISHING,
+        CANCELLING,
+        RELEASED
+    }
+
+    private final String taskId;
+    private final VoiceConnection<?, I, ?> connection;
+    private final WebSocketConnectionLease<?> lease;
+    private final Executor taskExecutor;
+    private final BooleanSupplier invalidateOnFinish;
+    private final CompletableFuture<Void> completion = new CompletableFuture<>();
+    private final Object lifecycleLock = new Object();
+    private Lifecycle lifecycle = Lifecycle.ACTIVE;
+
+    <P, O, C extends VoiceConnection<P, I, O>> WebSocketTaskSession(String taskId,
+                                                             C connection,
+                                                             WebSocketConnectionLease<C> lease,
+                                                             Executor taskExecutor,
+                                                             BooleanSupplier invalidateOnFinish) {
+        this.taskId = taskId;
+        this.connection = connection;
+        this.lease = lease;
+        this.taskExecutor = taskExecutor;
+        this.invalidateOnFinish = invalidateOnFinish;
+    }
+
+    public void send(I input) {
+        synchronized (lifecycleLock) {
+            connection.send(taskId, input);
+        }
+    }
+
+    public CompletionStage<Void> finish() {
+        synchronized (lifecycleLock) {
+            if (lifecycle != Lifecycle.ACTIVE) {
+                return completion;
+            }
+            lifecycle = Lifecycle.FINISHING;
+            try {
+                taskExecutor.execute(this::finishTask);
+            } catch (RuntimeException exception) {
+                lease.invalidate();
+                lifecycle = Lifecycle.RELEASED;
+                lease.close();
+                completion.completeExceptionally(exception);
+            }
+        }
+        return completion;
+    }
+
+    public void cancel() {
+        synchronized (lifecycleLock) {
+            lease.invalidate();
+            if (lifecycle == Lifecycle.RELEASED || lifecycle == Lifecycle.CANCELLING) {
+                return;
+            }
+            lifecycle = Lifecycle.CANCELLING;
+        }
+
+        Throwable failure = null;
+        try {
+            connection.cancelTask(taskId);
+        } catch (RuntimeException exception) {
+            failure = exception;
+            log.warn("WebSocket 任务取消失败，modelId={}，taskId={}", connection.modelId(), taskId, exception);
+        } finally {
+            synchronized (lifecycleLock) {
+                lifecycle = Lifecycle.RELEASED;
+            }
+            lease.close();
+            if (failure == null) {
+                completion.complete(null);
+            } else {
+                completion.completeExceptionally(failure);
+            }
+        }
+    }
+
+    private void finishTask() {
+        Throwable failure = null;
+        try {
+            connection.finishTask(taskId);
+        } catch (RuntimeException exception) {
+            failure = exception;
+            lease.invalidate();
+        }
+
+        boolean release;
+        synchronized (lifecycleLock) {
+            release = lifecycle == Lifecycle.FINISHING;
+            if (release) {
+                lifecycle = Lifecycle.RELEASED;
+            }
+        }
+        if (!release) {
+            return;
+        }
+
+        if (failure == null && invalidateOnFinish.getAsBoolean()) {
+            lease.invalidate();
+        }
+        lease.close();
+        if (failure == null) {
+            completion.complete(null);
+        } else {
+            completion.completeExceptionally(failure);
+        }
+    }
+}

--- a/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/voice/tts/BaiLianTtsClientTest.java
+++ b/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/voice/tts/BaiLianTtsClientTest.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BaiLianTtsClientTest {
+
+    private final Gson gson = new Gson();
+
+    @Test
+    void sendsMinimalCosyVoiceProtocolAndReturnsMp3() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory();
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties());
+        RecordingCallback callback = new RecordingCallback();
+
+        StreamCancellationHandle handle = client.synthesize(
+                "你好，世界。",
+                callback,
+                target()
+        );
+
+        JsonObject runTask = factory.messages.get(0);
+        JsonObject runPayload = runTask.getAsJsonObject("payload");
+        JsonObject parameters = runPayload.getAsJsonObject("parameters");
+        assertEquals(Set.of("text_type", "voice", "format"), parameters.keySet());
+        assertEquals("PlainText", parameters.get("text_type").getAsString());
+        assertEquals("longxiaochun", parameters.get("voice").getAsString());
+        assertEquals("mp3", parameters.get("format").getAsString());
+        assertEquals("audio", runPayload.get("task_group").getAsString());
+        assertEquals("cosyvoice-v3-flash", runPayload.get("model").getAsString());
+
+        assertEquals(List.of("run-task", "continue-task", "finish-task"), factory.actions());
+        assertEquals(1, factory.taskIds().stream().distinct().count());
+        assertEquals("你好，世界。", factory.messages.get(1)
+                .getAsJsonObject("payload")
+                .getAsJsonObject("input")
+                .get("text")
+                .getAsString());
+        assertEquals("Bearer test-key", factory.request.header("Authorization"));
+        assertEquals("test-workspace", factory.request.header("X-DashScope-WorkSpace"));
+        assertTrue(factory.request.url().isHttps());
+        assertEquals("dashscope.aliyuncs.com", factory.request.url().host());
+        assertEquals("/api-ws/v1/inference", factory.request.url().encodedPath());
+        assertArrayEquals(FakeWebSocketFactory.MP3_AUDIO, callback.audio);
+        assertTrue(callback.completed);
+
+        handle.cancel();
+        assertEquals(0, factory.closeCount.get());
+        client.close();
+    }
+
+    @Test
+    void splitsLongTextIntoSeparateContinueTasks() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory();
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties());
+
+        String longText = "测试".repeat(41);
+        client.synthesize(longText, new RecordingCallback(), target());
+
+        // run-task + 2 个 continue-task + finish-task
+        assertEquals(List.of("run-task", "continue-task", "continue-task", "finish-task"), factory.actions());
+        assertEquals(longText.substring(0, 80), factory.messages.get(1)
+                .getAsJsonObject("payload").getAsJsonObject("input").get("text").getAsString());
+        assertEquals(longText.substring(80), factory.messages.get(2)
+                .getAsJsonObject("payload").getAsJsonObject("input").get("text").getAsString());
+
+        client.close();
+    }
+
+    @Test
+    void waitsForFirstAudioUsingTtsTimeout() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(true, false, 450L, 0L);
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties(300L));
+        RecordingCallback callback = new RecordingCallback();
+
+        client.synthesize("延迟首帧", callback, target());
+
+        assertArrayEquals(FakeWebSocketFactory.MP3_AUDIO, callback.audio);
+        assertTrue(callback.completed);
+        assertNull(callback.error);
+        client.close();
+    }
+
+    @Test
+    void keepsFullFinishGraceWhenAudioArrivesBeforeFinishDirective() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(
+                true, false, 0L, 200L, true, 200L);
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties(300L));
+        RecordingCallback callback = new RecordingCallback();
+
+        client.synthesize("提前返回音频", callback, target());
+
+        assertArrayEquals(FakeWebSocketFactory.MP3_AUDIO, callback.audio);
+        assertTrue(callback.completed);
+        assertNull(callback.error);
+        client.close();
+    }
+
+    @Test
+    void renewsFinishWaitForEveryAudioFrame() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(
+                true, false, 0L, 200L, 3, 200L);
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties(300L));
+        RecordingCallback callback = new RecordingCallback();
+
+        client.synthesize("持续流式返回音频", callback, target());
+
+        assertArrayEquals(FakeWebSocketFactory.MP3_AUDIO, callback.audio);
+        assertTrue(callback.completed);
+        assertNull(callback.error);
+        client.close();
+    }
+
+    @Test
+    void timesOutWhenAudioFrameGapExceedsConfiguredIdleTimeout() {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(true, false, 0L, 450L);
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, Runnable::run, properties(300L));
+        RecordingCallback callback = new RecordingCallback();
+
+        client.synthesize("帧间超时", callback, target());
+
+        assertArrayEquals(FakeWebSocketFactory.MP3_AUDIO, callback.audio);
+        assertFalse(callback.completed);
+        assertNotNull(callback.error);
+        client.close();
+    }
+
+    @Test
+    void sendsCancelDirectiveBeforeFirstAudio() throws Exception {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(false);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, executor, properties());
+        RecordingCallback callback = new RecordingCallback();
+
+        try {
+            StreamCancellationHandle handle = client.synthesize("取消播放", callback, target());
+            assertTrue(factory.awaitNormalFinish());
+
+            handle.cancel();
+
+            JsonObject cancel = factory.messages.get(factory.messages.size() - 1);
+            assertEquals("finish-task", cancel.getAsJsonObject("header").get("action").getAsString());
+            assertEquals("cancel", cancel.getAsJsonObject("payload")
+                    .getAsJsonObject("input")
+                    .get("directive")
+                    .getAsString());
+            assertNull(callback.audio);
+            assertTrue(callback.completed);
+            assertEquals(1, factory.closeCount.get());
+        } finally {
+            client.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void invalidatesConnectionWhenCancelReceivesTaskFailed() throws Exception {
+        FakeWebSocketFactory factory = new FakeWebSocketFactory(false, true);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        BaiLianTtsClient client = new BaiLianTtsClient(factory, executor, properties());
+
+        try {
+            StreamCancellationHandle handle = client.synthesize("取消播放", new RecordingCallback(), target());
+            assertTrue(factory.awaitNormalFinish());
+
+            handle.cancel();
+
+            assertEquals(1, factory.closeCount.get());
+        } finally {
+            client.close();
+            executor.shutdownNow();
+        }
+    }
+
+    private ModelTarget target() {
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId("cosyvoice-v3-flash");
+        candidate.setProvider("bailian");
+        candidate.setModel("cosyvoice-v3-flash");
+        candidate.setVoice("longxiaochun");
+
+        AIModelProperties.ProviderConfig provider = new AIModelProperties.ProviderConfig();
+        provider.setUrl("https://dashscope.aliyuncs.com");
+        provider.setApiKey("test-key");
+        provider.setWorkspace("test-workspace");
+        provider.setEndpoints(Map.of("tts", "/api-ws/v1/inference"));
+        return new ModelTarget(candidate.getId(), candidate, provider, 1000L);
+    }
+
+    private AIModelProperties properties() {
+        return properties(1000L);
+    }
+
+    private AIModelProperties properties(long taskPacketIdleTimeoutMs) {
+        AIModelProperties.WebSocketConfig config = new AIModelProperties.WebSocketConfig();
+        config.setConnectTimeoutMs(1000L);
+        config.setTaskStartTimeoutMs(1000L);
+        config.setTaskPacketIdleTimeoutMs(taskPacketIdleTimeoutMs);
+        config.setMaxTotalPerModel(1);
+        config.setMaxIdlePerModel(1);
+
+        AIModelProperties properties = new AIModelProperties();
+        properties.setWebsocket(config);
+        return properties;
+    }
+
+    private static final class RecordingCallback implements TtsCallback {
+
+        private byte[] audio;
+        private boolean completed;
+        private Throwable error;
+
+        @Override
+        public void onAudio(byte[] audio) {
+            this.audio = audio;
+        }
+
+        @Override
+        public void onComplete() {
+            completed = true;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            error = throwable;
+        }
+    }
+
+    private final class FakeWebSocketFactory implements WebSocket.Factory {
+
+        private static final byte[] MP3_AUDIO = {73, 68, 51};
+
+        private final List<JsonObject> messages = new ArrayList<>();
+        private final AtomicInteger closeCount = new AtomicInteger();
+        private final CountDownLatch normalFinish = new CountDownLatch(1);
+        private final boolean autoFinish;
+        private final boolean failOnCancel;
+        private final long firstAudioDelayMs;
+        private final long finishDelayMs;
+        private final boolean audioBeforeFinish;
+        private final long continueTaskDelayMs;
+        private final int audioFrameCount;
+        private final long audioFrameIntervalMs;
+        private Request request;
+
+        private FakeWebSocketFactory() {
+            this(true, false, 0L, 0L);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish) {
+            this(autoFinish, false, 0L, 0L);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish, boolean failOnCancel) {
+            this(autoFinish, failOnCancel, 0L, 0L);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish, boolean failOnCancel,
+                                     long firstAudioDelayMs, long finishDelayMs) {
+            this(autoFinish, failOnCancel, firstAudioDelayMs, finishDelayMs, false, 0L, 1, 0L);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish, boolean failOnCancel,
+                                     long firstAudioDelayMs, long finishDelayMs,
+                                     boolean audioBeforeFinish, long continueTaskDelayMs) {
+            this(autoFinish, failOnCancel, firstAudioDelayMs, finishDelayMs,
+                    audioBeforeFinish, continueTaskDelayMs, 1, 0L);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish, boolean failOnCancel,
+                                     long firstAudioDelayMs, long finishDelayMs,
+                                     int audioFrameCount, long audioFrameIntervalMs) {
+            this(autoFinish, failOnCancel, firstAudioDelayMs, finishDelayMs,
+                    false, 0L, audioFrameCount, audioFrameIntervalMs);
+        }
+
+        private FakeWebSocketFactory(boolean autoFinish, boolean failOnCancel,
+                                     long firstAudioDelayMs, long finishDelayMs,
+                                     boolean audioBeforeFinish, long continueTaskDelayMs,
+                                     int audioFrameCount, long audioFrameIntervalMs) {
+            this.autoFinish = autoFinish;
+            this.failOnCancel = failOnCancel;
+            this.firstAudioDelayMs = firstAudioDelayMs;
+            this.finishDelayMs = finishDelayMs;
+            this.audioBeforeFinish = audioBeforeFinish;
+            this.continueTaskDelayMs = continueTaskDelayMs;
+            this.audioFrameCount = audioFrameCount;
+            this.audioFrameIntervalMs = audioFrameIntervalMs;
+        }
+
+        @Override
+        public WebSocket newWebSocket(Request request, WebSocketListener listener) {
+            this.request = request;
+            FakeWebSocket webSocket = new FakeWebSocket(request, listener);
+            Response response = new Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(101)
+                    .message("Switching Protocols")
+                    .build();
+            listener.onOpen(webSocket, response);
+            return webSocket;
+        }
+
+        private List<String> actions() {
+            return messages.stream()
+                    .map(message -> message.getAsJsonObject("header").get("action").getAsString())
+                    .toList();
+        }
+
+        private List<String> taskIds() {
+            return messages.stream()
+                    .map(message -> message.getAsJsonObject("header").get("task_id").getAsString())
+                    .toList();
+        }
+
+        private boolean awaitNormalFinish() throws InterruptedException {
+            return normalFinish.await(1, TimeUnit.SECONDS);
+        }
+
+        private final class FakeWebSocket implements WebSocket {
+
+            private final Request request;
+            private final WebSocketListener listener;
+
+            private FakeWebSocket(Request request, WebSocketListener listener) {
+                this.request = request;
+                this.listener = listener;
+            }
+
+            @Override
+            public Request request() {
+                return request;
+            }
+
+            @Override
+            public long queueSize() {
+                return 0;
+            }
+
+            @Override
+            public boolean send(String text) {
+                JsonObject message = gson.fromJson(text, JsonObject.class);
+                messages.add(message);
+                String action = message.getAsJsonObject("header").get("action").getAsString();
+                String taskId = message.getAsJsonObject("header").get("task_id").getAsString();
+                if ("run-task".equals(action)) {
+                    listener.onMessage(this, event(taskId, "task-started"));
+                } else if ("continue-task".equals(action) && audioBeforeFinish) {
+                    listener.onMessage(this, ByteString.of(MP3_AUDIO));
+                    sleep(continueTaskDelayMs);
+                } else if ("finish-task".equals(action)) {
+                    JsonObject input = message.getAsJsonObject("payload").getAsJsonObject("input");
+                    if (input.has("directive")) {
+                        listener.onMessage(this, event(taskId, failOnCancel ? "task-failed" : "task-finished"));
+                    } else {
+                        normalFinish.countDown();
+                        if (autoFinish) {
+                            respondWithAudio(taskId);
+                        }
+                    }
+                }
+                return true;
+            }
+
+            private void respondWithAudio(String taskId) {
+                Runnable response = () -> {
+                    if (!audioBeforeFinish) {
+                        sleep(firstAudioDelayMs);
+                        for (int frame = 0; frame < audioFrameCount; frame++) {
+                            if (frame > 0) {
+                                sleep(audioFrameIntervalMs);
+                            }
+                            listener.onMessage(this, ByteString.of(MP3_AUDIO));
+                        }
+                    }
+                    sleep(finishDelayMs);
+                    listener.onMessage(this, event(taskId, "task-finished"));
+                };
+                if (firstAudioDelayMs == 0L && finishDelayMs == 0L) {
+                    response.run();
+                    return;
+                }
+                Thread responseThread = new Thread(response, "fake-tts-response");
+                responseThread.setDaemon(true);
+                responseThread.start();
+            }
+
+            private void sleep(long delayMs) {
+                if (delayMs <= 0L) {
+                    return;
+                }
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public boolean send(ByteString bytes) {
+                return true;
+            }
+
+            @Override
+            public boolean close(int code, String reason) {
+                closeCount.incrementAndGet();
+                listener.onClosed(this, code, reason == null ? "" : reason);
+                return true;
+            }
+
+            @Override
+            public void cancel() {
+            }
+
+            private String event(String taskId, String event) {
+                JsonObject header = new JsonObject();
+                header.addProperty("task_id", taskId);
+                header.addProperty("event", event);
+                JsonObject response = new JsonObject();
+                response.add("header", header);
+                response.add("payload", new JsonObject());
+                return gson.toJson(response);
+            }
+        }
+    }
+}

--- a/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/voice/tts/RoutingTtsServiceTest.java
+++ b/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/voice/tts/RoutingTtsServiceTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.voice.tts;
+
+import com.nageoffer.ai.ragent.framework.exception.RemoteException;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.http.ModelClientErrorType;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.model.ModelHealthStore;
+import com.nageoffer.ai.ragent.infra.model.ModelSelector;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoutingTtsServiceTest {
+
+    @Test
+    void usesModelHealthStoreForConsecutiveFailures() {
+        AIModelProperties properties = singleModelProperties();
+        ModelHealthStore healthStore = new ModelHealthStore(properties);
+        FailingTtsClient client = new FailingTtsClient("test");
+        RoutingTtsService service = service(properties, healthStore, List.of(client));
+
+        assertThrows(RemoteException.class,
+                () -> service.synthesize("第一次", new RecordingCallback()));
+        assertFalse(healthStore.isUnavailable("tts-model"));
+
+        assertThrows(RemoteException.class,
+                () -> service.synthesize("第二次", new RecordingCallback()));
+        assertTrue(healthStore.isUnavailable("tts-model"));
+        assertEquals(2, client.attempts.get());
+        assertEquals(2, client.invalidatingCancellations.get());
+    }
+
+    @Test
+    void discardsFailedCandidateEventsAndCommitsFirstAudioFromFallback() {
+        AIModelProperties properties = fallbackProperties();
+        ModelHealthStore healthStore = new ModelHealthStore(properties);
+        FailingTtsClient primary = new FailingTtsClient("primary");
+        SuccessfulTtsClient backup = new SuccessfulTtsClient("backup", new byte[]{2, 3});
+        RoutingTtsService service = service(properties, healthStore, List.of(primary, backup));
+        RecordingCallback callback = new RecordingCallback();
+
+        StreamCancellationHandle handle = service.synthesize("你好", callback);
+
+        assertArrayEquals(new byte[]{2, 3}, callback.audioEvents.get(0));
+        assertEquals(1, callback.audioEvents.size());
+        assertTrue(callback.completed);
+        assertEquals(0, callback.errors.get());
+        assertEquals(1, primary.attempts.get());
+        assertEquals(1, backup.attempts.get());
+        handle.cancel();
+    }
+
+    @Test
+    void releasesHalfOpenPermitWhenStartedTaskIsCancelledBeforeFirstAudio() {
+        AIModelProperties properties = fallbackProperties();
+        properties.getSelection().setFailureThreshold(1);
+        properties.getSelection().setOpenDurationMs(0L);
+        ModelHealthStore healthStore = new ModelHealthStore(properties);
+        CancelCompletingTtsClient primary = new CancelCompletingTtsClient("primary");
+        SuccessfulTtsClient backup = new SuccessfulTtsClient("backup", new byte[]{2, 3});
+        RoutingTtsService service = service(properties, healthStore, List.of(primary, backup));
+        RecordingCallback callback = new RecordingCallback();
+        AtomicBoolean cancelled = new AtomicBoolean();
+        healthStore.markFailure("primary-model");
+
+        service.synthesize("立即取消", callback, new TtsTaskObserver() {
+            @Override
+            public void onTaskStarted(StreamCancellationHandle handle) {
+                cancelled.set(true);
+                handle.cancel();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return cancelled.get();
+            }
+        });
+
+        assertEquals(1, primary.cancellations.get());
+        assertEquals(0, backup.attempts.get());
+        assertTrue(callback.audioEvents.isEmpty());
+        assertFalse(callback.completed);
+        assertEquals(0, callback.errors.get());
+        assertFalse(healthStore.isUnavailable("primary-model"));
+        assertNotNull(healthStore.allowCall("primary-model"));
+    }
+
+    @Test
+    void releasesHalfOpenPermitWhenConnectionPoolIsExhausted() {
+        AIModelProperties properties = singleModelProperties();
+        properties.getSelection().setFailureThreshold(1);
+        properties.getSelection().setOpenDurationMs(0L);
+        ModelHealthStore healthStore = new ModelHealthStore(properties);
+        PoolExhaustedTtsClient client = new PoolExhaustedTtsClient("test");
+        RoutingTtsService service = service(properties, healthStore, List.of(client));
+        healthStore.markFailure("tts-model");
+
+        assertThrows(RemoteException.class,
+                () -> service.synthesize("连接池耗尽", new RecordingCallback()));
+
+        assertEquals(1, client.attempts.get());
+        assertFalse(healthStore.isUnavailable("tts-model"));
+        assertNotNull(healthStore.allowCall("tts-model"));
+    }
+
+    private RoutingTtsService service(AIModelProperties properties,
+                                      ModelHealthStore healthStore,
+                                      List<TtsClient> clients) {
+        return new RoutingTtsService(
+                new ModelSelector(properties, healthStore),
+                healthStore,
+                clients
+        );
+    }
+
+    private AIModelProperties singleModelProperties() {
+        AIModelProperties properties = new AIModelProperties();
+        properties.getProviders().put("test", new AIModelProperties.ProviderConfig());
+        properties.getTts().setDefaultModel("tts-model");
+        properties.getTts().setTimeoutMs(1000L);
+        properties.getTts().setCandidates(List.of(candidate("tts-model", "test", 1)));
+        return properties;
+    }
+
+    private AIModelProperties fallbackProperties() {
+        AIModelProperties properties = new AIModelProperties();
+        properties.getProviders().put("primary", new AIModelProperties.ProviderConfig());
+        properties.getProviders().put("backup", new AIModelProperties.ProviderConfig());
+        properties.getTts().setDefaultModel("primary-model");
+        properties.getTts().setTimeoutMs(1000L);
+        properties.getTts().setCandidates(List.of(
+                candidate("primary-model", "primary", 1),
+                candidate("backup-model", "backup", 2)
+        ));
+        return properties;
+    }
+
+    private AIModelProperties.ModelCandidate candidate(String id, String provider, int priority) {
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId(id);
+        candidate.setProvider(provider);
+        candidate.setModel(id);
+        candidate.setPriority(priority);
+        return candidate;
+    }
+
+    private static final class FailingTtsClient implements TtsClient {
+
+        private final String provider;
+        private final AtomicInteger attempts = new AtomicInteger();
+        private final AtomicInteger invalidatingCancellations = new AtomicInteger();
+
+        private FailingTtsClient(String provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public String provider() {
+            return provider;
+        }
+
+        @Override
+        public StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target) {
+            attempts.incrementAndGet();
+            callback.onError(new IllegalStateException("provider failed"));
+            return invalidatingCancellations::incrementAndGet;
+        }
+    }
+
+    private static final class SuccessfulTtsClient implements TtsClient {
+
+        private final String provider;
+        private final byte[] audio;
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        private SuccessfulTtsClient(String provider, byte[] audio) {
+            this.provider = provider;
+            this.audio = audio;
+        }
+
+        @Override
+        public String provider() {
+            return provider;
+        }
+
+        @Override
+        public StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target) {
+            attempts.incrementAndGet();
+            callback.onAudio(audio);
+            callback.onComplete();
+            return () -> {
+            };
+        }
+    }
+
+    private static final class CancelCompletingTtsClient implements TtsClient {
+
+        private final String provider;
+        private final AtomicInteger cancellations = new AtomicInteger();
+
+        private CancelCompletingTtsClient(String provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public String provider() {
+            return provider;
+        }
+
+        @Override
+        public StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target) {
+            return () -> {
+                cancellations.incrementAndGet();
+                callback.onComplete();
+            };
+        }
+    }
+
+    private static final class PoolExhaustedTtsClient implements TtsClient {
+
+        private final String provider;
+        private final AtomicInteger attempts = new AtomicInteger();
+
+        private PoolExhaustedTtsClient(String provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public String provider() {
+            return provider;
+        }
+
+        @Override
+        public StreamCancellationHandle synthesize(String text, TtsCallback callback, ModelTarget target) {
+            attempts.incrementAndGet();
+            throw new ModelClientException("pool exhausted", ModelClientErrorType.RATE_LIMITED, null);
+        }
+    }
+
+    private static final class RecordingCallback implements TtsCallback {
+
+        private final List<byte[]> audioEvents = new ArrayList<>();
+        private final AtomicInteger errors = new AtomicInteger();
+        private boolean completed;
+
+        @Override
+        public void onAudio(byte[] audio) {
+            audioEvents.add(audio);
+        }
+
+        @Override
+        public void onComplete() {
+            completed = true;
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            errors.incrementAndGet();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <commonmark.version>0.22.0</commonmark.version>
         <batik.version>1.18</batik.version>
         <okhttp.version>5.3.2</okhttp.version>
+        <commons-pool2.version>2.12.1</commons-pool2.version>
         <mcp-sdk.version>1.1.2</mcp-sdk.version>
         <agentscope.version>2.0.2</agentscope.version>
         <bizlog-sdk.version>3.0.6</bizlog-sdk.version>
@@ -176,6 +177,12 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-jvm</artifactId>
                 <version>${okhttp.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool2.version}</version>
             </dependency>
 
             <dependency>

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/ThreadPoolExecutorConfig.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/ThreadPoolExecutorConfig.java
@@ -199,6 +199,30 @@ public class ThreadPoolExecutorConfig {
     }
 
     /**
+     * 消息语音播放合成线程池
+     */
+    @Bean
+    public Executor voicePlaybackExecutor(
+            @Value("${rag.voice.executors.playback.core-pool-size}") int corePoolSize,
+            @Value("${rag.voice.executors.playback.max-pool-size}") int maxPoolSize,
+            @Value("${rag.voice.executors.playback.keep-alive-seconds}") long keepAliveSeconds,
+            @Value("${rag.voice.executors.playback.thread-name-prefix}") String threadNamePrefix) {
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                corePoolSize,
+                maxPoolSize,
+                keepAliveSeconds,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                ThreadFactoryBuilder.create()
+                        .setNamePrefix(threadNamePrefix)
+                        .build(),
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        executor.allowCoreThreadTimeOut(true);
+        return TtlExecutors.getTtlExecutor(executor);
+    }
+
+    /**
      * SSE 排队后执行入口线程池
      */
     @Bean

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/ThreadPoolExecutorConfig.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/ThreadPoolExecutorConfig.java
@@ -19,6 +19,7 @@ package com.nageoffer.ai.ragent.rag.config;
 
 import cn.hutool.core.thread.ThreadFactoryBuilder;
 import com.alibaba.ttl.threadpool.TtlExecutors;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -170,6 +171,30 @@ public class ThreadPoolExecutorConfig {
                         .build(),
                 new ThreadPoolExecutor.AbortPolicy()
         );
+        return TtlExecutors.getTtlExecutor(executor);
+    }
+
+    /**
+     * Voice WebSocket 任务收尾线程池
+     */
+    @Bean
+    public Executor webSocketLifecycleExecutor(
+            @Value("${rag.voice.executors.websocket-lifecycle.core-pool-size}") int corePoolSize,
+            @Value("${rag.voice.executors.websocket-lifecycle.max-pool-size}") int maxPoolSize,
+            @Value("${rag.voice.executors.websocket-lifecycle.keep-alive-seconds}") long keepAliveSeconds,
+            @Value("${rag.voice.executors.websocket-lifecycle.thread-name-prefix}") String threadNamePrefix) {
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                corePoolSize,
+                maxPoolSize,
+                keepAliveSeconds,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                ThreadFactoryBuilder.create()
+                        .setNamePrefix(threadNamePrefix)
+                        .build(),
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        executor.allowCoreThreadTimeOut(true);
         return TtlExecutors.getTtlExecutor(executor);
     }
 

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/VoicePlaybackController.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/VoicePlaybackController.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.controller;
+
+import com.nageoffer.ai.ragent.framework.convention.Result;
+import com.nageoffer.ai.ragent.framework.idempotent.IdempotentSubmit;
+import com.nageoffer.ai.ragent.framework.web.Results;
+import com.nageoffer.ai.ragent.rag.config.RAGDefaultProperties;
+import com.nageoffer.ai.ragent.rag.service.VoicePlaybackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 消息语音播放控制器
+ */
+@RestController
+@RequiredArgsConstructor
+public class VoicePlaybackController {
+
+    private final VoicePlaybackService voicePlaybackService;
+    private final RAGDefaultProperties ragDefaultProperties;
+
+    /**
+     * 发起消息语音播放
+     */
+    @GetMapping(value = "/rag/v3/voice/play", produces = "text/event-stream;charset=UTF-8")
+    public SseEmitter play(@RequestParam String messageId) {
+        SseEmitter emitter = new SseEmitter(ragDefaultProperties.getSseTimeoutMs());
+        voicePlaybackService.play(messageId, emitter);
+        return emitter;
+    }
+
+    /**
+     * 停止指定播放任务
+     */
+    @IdempotentSubmit
+    @PostMapping(value = "/rag/v3/voice/stop")
+    public Result<Void> stop(@RequestParam String taskId) {
+        voicePlaybackService.stop(taskId);
+        return Results.success();
+    }
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/AudioFramePayload.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/AudioFramePayload.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.dto;
+
+/**
+ * 音频帧事件载荷
+ */
+public record AudioFramePayload(String base64) {
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/AudioMetaPayload.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/dto/AudioMetaPayload.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.dto;
+
+/**
+ * 音频元信息事件载荷
+ */
+public record AudioMetaPayload(String taskId) {
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/VoicePlaybackService.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/VoicePlaybackService.java
@@ -15,62 +15,22 @@
  * limitations under the License.
  */
 
-package com.nageoffer.ai.ragent.rag.enums;
+package com.nageoffer.ai.ragent.rag.service;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
- * SSE 事件类型枚举
+ * 消息语音播放服务
  */
-@RequiredArgsConstructor
-public enum SSEEventType {
+public interface VoicePlaybackService {
 
     /**
-     * 会话与任务的元信息事件
+     * 播放指定消息
      */
-    META("meta"),
+    void play(String messageId, SseEmitter emitter);
 
     /**
-     * 增量消息事件
+     * 停止指定播放任务
      */
-    MESSAGE("message"),
-
-    /**
-     * 模型回复完成事件
-     */
-    FINISH("finish"),
-
-    /**
-     * 完成事件
-     */
-    DONE("done"),
-
-    /**
-     * 取消事件
-     */
-    CANCEL("cancel"),
-
-    /**
-     * 拒绝事件
-     */
-    REJECT("reject"),
-
-    /**
-     * 音频帧事件
-     */
-    AUDIO("audio"),
-
-    /**
-     * 音频元信息事件
-     */
-    AUDIO_META("audio-meta");
-
-    private final String value;
-
-    /**
-     * SSE 事件名称（与前端约定一致）
-     */
-    public String value() {
-        return value;
-    }
+    void stop(String taskId);
 }

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamCallbackFactory.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/StreamCallbackFactory.java
@@ -62,4 +62,11 @@ public class StreamCallbackFactory {
 
         return new StreamChatEventHandler(params);
     }
+
+    /**
+     * 创建语音播放事件处理器
+     */
+    public VoicePlaybackEventHandler createVoicePlaybackEventHandler(SseEmitter emitter, String taskId) {
+        return new VoicePlaybackEventHandler(emitter, taskId, taskManager);
+    }
 }

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackEventHandler.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackEventHandler.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.framework.web.SseEmitterSender;
+import com.nageoffer.ai.ragent.framework.web.StreamTaskManager;
+import com.nageoffer.ai.ragent.infra.chat.StreamCancellationHandle;
+import com.nageoffer.ai.ragent.infra.voice.tts.TtsCallback;
+import com.nageoffer.ai.ragent.infra.voice.tts.TtsTaskObserver;
+import com.nageoffer.ai.ragent.rag.dto.AudioFramePayload;
+import com.nageoffer.ai.ragent.rag.dto.AudioMetaPayload;
+import com.nageoffer.ai.ragent.rag.dto.CompletionPayload;
+import com.nageoffer.ai.ragent.rag.enums.SSEEventType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 语音播放 SSE 事件处理器
+ */
+@Slf4j
+public class VoicePlaybackEventHandler implements TtsCallback, TtsTaskObserver {
+
+    private final String taskId;
+    private final SseEmitterSender sender;
+    private final StreamTaskManager taskManager;
+    private final AtomicBoolean terminated = new AtomicBoolean();
+    private final AtomicBoolean firstFrameLogged = new AtomicBoolean();
+
+    public VoicePlaybackEventHandler(SseEmitter emitter, String taskId, StreamTaskManager taskManager) {
+        this.taskId = taskId;
+        this.sender = new SseEmitterSender(emitter);
+        this.taskManager = taskManager;
+        initialize(emitter);
+    }
+
+    private void initialize(SseEmitter emitter) {
+        taskManager.register(taskId, () -> {
+            sender.sendEvent(SSEEventType.CANCEL.value(), new CompletionPayload(null, null));
+            sender.sendEvent(SSEEventType.DONE.value(), "[DONE]");
+            sender.complete();
+        });
+        bindEmitterCancellation(emitter);
+        sender.sendEvent(SSEEventType.AUDIO_META.value(), new AudioMetaPayload(taskId));
+        log.info("播放任务发起，taskId={}", taskId);
+    }
+
+    @Override
+    public void onTaskStarted(StreamCancellationHandle handle) {
+        taskManager.bindHandle(taskId, wrapCancellationHandle(handle)::cancel);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return taskManager.isCancelled(taskId);
+    }
+
+    String taskId() {
+        return taskId;
+    }
+
+    @Override
+    public void onAudio(byte[] audio) {
+        if (terminated.get() || isCancelled()) {
+            return;
+        }
+        if (firstFrameLogged.compareAndSet(false, true)) {
+            log.info("播放任务首帧下发，taskId={}", taskId);
+        }
+        sender.sendEvent(SSEEventType.AUDIO.value(), new AudioFramePayload(
+                Base64.getEncoder().encodeToString(audio)));
+    }
+
+    @Override
+    public void onComplete() {
+        if (isCancelled() || !terminated.compareAndSet(false, true)) {
+            return;
+        }
+        log.info("播放任务完成，taskId={}", taskId);
+        sender.sendEvent(SSEEventType.DONE.value(), "[DONE]");
+        taskManager.unregister(taskId);
+        sender.complete();
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        terminateWithError("播放任务失败，taskId={}", throwable);
+    }
+
+    public void onStartFailure(Throwable throwable) {
+        if (isCancelled()) {
+            log.info("播放任务已取消，忽略启动异常，taskId={}", taskId);
+            taskManager.unregister(taskId);
+            return;
+        }
+        terminateWithError("播放任务启动失败，taskId={}", throwable);
+    }
+
+    public void onRejected(Throwable throwable) {
+        terminateWithError("播放任务线程池拒绝，taskId={}", throwable);
+    }
+
+    private void terminateWithError(String message, Throwable throwable) {
+        if (isCancelled() || !terminated.compareAndSet(false, true)) {
+            return;
+        }
+        log.error(message, taskId, throwable);
+        taskManager.unregister(taskId);
+        sender.fail(throwable);
+    }
+
+    private void bindEmitterCancellation(SseEmitter emitter) {
+        Runnable cancel = () -> {
+            if (terminated.compareAndSet(false, true) && !isCancelled()) {
+                taskManager.cancel(taskId);
+            }
+        };
+        emitter.onCompletion(cancel);
+        emitter.onTimeout(cancel);
+        emitter.onError(ignored -> cancel.run());
+    }
+
+    private StreamCancellationHandle wrapCancellationHandle(StreamCancellationHandle handle) {
+        // 取消指令与已在途的 finish-task 存在竞态，停止后不复用当前连接
+        return () -> {
+            try {
+                handle.cancel();
+                log.info("播放任务已取消，taskId={}", taskId);
+            } catch (RuntimeException exception) {
+                log.warn("播放任务取消失败，taskId={}", taskId, exception);
+            }
+        };
+    }
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackTaskRunner.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/handler/VoicePlaybackTaskRunner.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.handler;
+
+import com.nageoffer.ai.ragent.infra.voice.tts.TtsService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * 在线程池中启动语音播放任务
+ */
+@Slf4j
+@Component
+public class VoicePlaybackTaskRunner {
+
+    private final TtsService ttsService;
+    private final Executor voicePlaybackExecutor;
+
+    public VoicePlaybackTaskRunner(TtsService ttsService,
+                                   @Qualifier("voicePlaybackExecutor") Executor voicePlaybackExecutor) {
+        this.ttsService = ttsService;
+        this.voicePlaybackExecutor = voicePlaybackExecutor;
+    }
+
+    public void run(String text, VoicePlaybackEventHandler callback) {
+        try {
+            voicePlaybackExecutor.execute(() -> synthesize(text, callback));
+        } catch (RejectedExecutionException exception) {
+            callback.onRejected(exception);
+        }
+    }
+
+    private void synthesize(String text, VoicePlaybackEventHandler callback) {
+        if (callback.isCancelled()) {
+            return;
+        }
+        try {
+            ttsService.synthesize(text, callback, callback);
+            log.info("播放任务已启动，taskId={}", callback.taskId());
+        } catch (RuntimeException exception) {
+            callback.onStartFailure(exception);
+        }
+    }
+}

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/VoicePlaybackServiceImpl.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/service/impl/VoicePlaybackServiceImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.service.impl;
+
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.core.util.IdUtil;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.nageoffer.ai.ragent.framework.context.UserContext;
+import com.nageoffer.ai.ragent.framework.exception.ClientException;
+import com.nageoffer.ai.ragent.framework.web.StreamTaskManager;
+import com.nageoffer.ai.ragent.rag.dao.entity.ConversationMessageDO;
+import com.nageoffer.ai.ragent.rag.dao.mapper.ConversationMessageMapper;
+import com.nageoffer.ai.ragent.rag.service.VoicePlaybackService;
+import com.nageoffer.ai.ragent.rag.service.handler.StreamCallbackFactory;
+import com.nageoffer.ai.ragent.rag.service.handler.VoicePlaybackEventHandler;
+import com.nageoffer.ai.ragent.rag.service.handler.VoicePlaybackTaskRunner;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * 消息语音播放服务默认实现
+ */
+@Service
+@RequiredArgsConstructor
+public class VoicePlaybackServiceImpl implements VoicePlaybackService {
+
+    private static final String ROLE_ASSISTANT = "assistant";
+
+    private final ConversationMessageMapper conversationMessageMapper;
+    private final StreamCallbackFactory callbackFactory;
+    private final VoicePlaybackTaskRunner taskRunner;
+    private final StreamTaskManager taskManager;
+
+    @Override
+    public void play(String messageId, SseEmitter emitter) {
+        String taskId = IdUtil.getSnowflakeNextIdStr();
+        ConversationMessageDO message = loadAssistantMessage(messageId, UserContext.getUserId());
+        String text = message.getContent();
+        if (StrUtil.isBlank(text)) {
+            throw new ClientException("消息内容为空，无法播放");
+        }
+
+        VoicePlaybackEventHandler callback = callbackFactory.createVoicePlaybackEventHandler(emitter, taskId);
+        taskRunner.run(text, callback);
+    }
+
+    @Override
+    public void stop(String taskId) {
+        taskManager.cancel(taskId);
+    }
+
+    /**
+     * 定位当前用户的 assistant 消息
+     */
+    private ConversationMessageDO loadAssistantMessage(String messageId, String userId) {
+        ConversationMessageDO message = conversationMessageMapper.selectOne(
+                Wrappers.lambdaQuery(ConversationMessageDO.class)
+                        .eq(ConversationMessageDO::getId, messageId)
+                        .eq(ConversationMessageDO::getUserId, userId)
+                        .eq(ConversationMessageDO::getRole, ROLE_ASSISTANT)
+                        .eq(ConversationMessageDO::getDeleted, 0)
+        );
+        if (message == null) {
+            throw new ClientException("消息不存在");
+        }
+        return message;
+    }
+}

--- a/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/ModelSelectorTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/ModelSelectorTest.java
@@ -161,4 +161,17 @@ class ModelSelectorTest {
         List<ModelTarget> targets = selector.selectChatCandidates(false);
         assertEquals(List.of("qwen3-local", "gpt-5.4"), ids(targets));
     }
+
+    @Test
+    void TTS模型组超时写入ModelTarget统一超时() {
+        AIModelProperties.ModelCandidate ttsCandidate = cand("tts-model", "bailian", "tts-model", false);
+        properties.getTts().setDefaultModel("tts-model");
+        properties.getTts().setCandidates(List.of(ttsCandidate));
+        properties.getTts().setTimeoutMs(1000L);
+
+        List<ModelTarget> targets = selector.selectTtsCandidates();
+
+        assertEquals(List.of("tts-model"), ids(targets));
+        assertEquals(1000L, targets.get(0).timeoutMs());
+    }
 }


### PR DESCRIPTION
演示视频：[ragent-语音播放功能演示](https://www.bilibili.com/video/BV18Du36gEzc?vd_source=1258e036eb41f172b62821a57f402efa)

Closes #108

## 背景

当前聊天消息仅支持文本阅读。为了让用户直接收听已生成的 assistant 消息，本次新增端到端的流式 TTS 播放能力：后端从消息记录读取文本，通过池化 WebSocket 调用百炼 CosyVoice，并使用 SSE 将 MP3 音频帧持续推送给浏览器；前端基于 MediaSource 边接收、边缓冲、边播放。

同时抽象了可复用的 Voice WebSocket 连接与任务生命周期，避免每次播放都重新建立物理连接，并收敛成便于扩展其他基于 WebSocket 的流式语音能力。

## 设计参考

- [阿里云百炼实时语音合成使用指南](https://help.aliyun.com/zh/model-studio/realtime-tts-user-guide#ug-hc-h3)
- [火山引擎流式语音合成文档](https://docs.volcengine.com/docs/6561/1329505?lang=zh)

## 主要变更

- 新增消息语音播放与停止接口，通过 SSE 向浏览器持续推送 MP3 音频帧。
- 前端使用 MediaSource 边接收边播放，并支持再次点击、切换或删除会话时停止播放。
- 新增 TTS 模型路由和首音频探测，候选失败时自动取消并尝试后续模型。
- 接入百炼 CosyVoice WebSocket，完成文本分片发送、音频回调和任务终态处理。
- 新增按模型隔离的 WebSocket 连接池；正常完成后复用连接，取消或异常时废弃连接。
- 将任务等待调整为首帧超时与音频包空闲超时，并补充相关配置、线程池和测试。

## 接口与事件约定

- `GET /rag/v3/voice/play?messageId=...`：建立语音播放 SSE。
- `POST /rag/v3/voice/stop?taskId=...`：停止播放任务。
- 正常播放的 SSE 事件顺序为 `audio-meta` → `audio` × N → `done`；`audio-meta` 携带任务 ID，`audio` 携带 Base64 MP3 音频帧。

## 完整流程

1. 用户点击 assistant 消息的语音按钮。
2. 前端请求 `/rag/v3/voice/play`，后端校验并读取当前用户的消息文本。
3. 后端先发送 `audio-meta(taskId)`，随后在线程池中异步调用 `TtsService`。
4. TTS 路由选择健康候选，并从对应 `modelId` 的连接池借用 WebSocket。
5. 客户端发送 `run-task`、分块 `continue-task` 和 `finish-task`。
6. 百炼持续返回 MP3 二进制帧；首帧探测成功后，音频通过回调和 SSE 透传给前端。
7. 前端把音频帧依次追加到 MSE 缓冲区，首帧入缓冲后开始播放。
8. 收到 `task-finished` 后发送 `done`、关闭 SSE，并将正常连接归还池中。
9. 用户主动停止时取消任务并清理本地播放资源，当前 WebSocket 连接不再复用。

## 设计图

### WebSocket 包

展示连接资源生命周期与任务生命周期如何汇聚到物理连接核心。

<img width="2000" height="1212" alt="image" src="https://github.com/user-attachments/assets/f4db6d37-ff95-442a-bd9d-1f790366729f" />

### TTS 包

展示 TTS 业务入口、候选路由、首音频探测桥接、任务观察者及供应商 WebSocket 客户端之间的职责与继承关系。

<img width="2000" height="1212" alt="image" src="https://github.com/user-attachments/assets/3ffc35e5-11db-4394-8f60-9628321b439e" />

### WebSocket 单连接生命周期

展示单条物理连接从建立、执行任务、正常复用，到取消、异常及关闭的状态变化。

<img width="2000" height="633" alt="image" src="https://github.com/user-attachments/assets/ab4f4549-7bf8-4599-9bb1-8408e838a301" />

### TTS 正常播放时序

展示播放请求、模型选择、流式音频通过 SSE 进入 MSE 播放，以及正常完成后的连接复用。

<img width="1436" height="1583" alt="image" src="https://github.com/user-attachments/assets/53de0408-8a86-44c7-beeb-6bac8d3bdda2" />

### TTS 取消时序

展示用户发起停止后立即清理本地播放器，后端异步取消远端合成、销毁不可复用连接，并在取消完成后关闭 SSE。

<img width="2000" height="1694" alt="image" src="https://github.com/user-attachments/assets/e9677156-f439-47ac-87ca-0c93a4675c66" />

## 验证结果

- [x] `BaiLianTtsClientTest`：8 个测试通过。
- [x] `RoutingTtsServiceTest`：4 个测试通过。
- [x] `ModelSelectorTest`：10 个测试通过，包含 TTS 候选和统一超时映射。
- [x] 前端 `npm run build` 通过。
- [x] `git diff --check` 通过。
- [x] 新增配置项已提供默认值和示例。
- [x] 已使用真实百炼环境完成端到端人工验证（见演示视频）。