### PR TITLE
feat(vlm): 支持vlm单独配置请求超时时间

### DIFF
--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -292,6 +292,7 @@ ai:
 
   vlm:
     default-model: qwen-vl-max
+    timeout-ms: 120000
     candidates:
       - id: qwen-vl-max
         provider: bailian

--- a/frontend/src/pages/admin/settings/SystemSettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/SystemSettingsPage.tsx
@@ -270,9 +270,17 @@ function ModelCandidatesCard({
     <div className="settings-card">
       <div className="settings-card-title">
         {title}
-        {group.defaultModel ? (
+        {group.defaultModel || group.timeoutMs != null ? (
           <span className="settings-card-title-hint">
-            默认 <code className="font-mono text-slate-500">{group.defaultModel}</code>
+            {group.defaultModel ? (
+              <>
+                默认 <code className="font-mono text-slate-500">{group.defaultModel}</code>
+              </>
+            ) : null}
+            {group.defaultModel && group.timeoutMs != null ? (
+              <span className="mx-1.5 text-slate-200">|</span>
+            ) : null}
+            {group.timeoutMs != null ? `超时 ${formatDurationMs(group.timeoutMs)}` : null}
           </span>
         ) : null}
       </div>

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -120,6 +120,7 @@ export interface RetrievalChannel {
 
 export interface ModelGroup {
   defaultModel?: string | null;
+  timeoutMs?: number | null;
   candidates: ModelCandidate[];
   // chat 组档位机制字段，embedding/rerank/vlm 为空
   defaultTier?: string | null;

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/config/AIModelProperties.java
@@ -83,6 +83,11 @@ public class AIModelProperties {
         private String defaultModel;
 
         /**
+         * 同步调用超时预算（毫秒，当前用于 VLM）
+         */
+        private Long timeoutMs;
+
+        /**
          * 候选模型列表
          * <p>
          * chat 组下退化为"物理模型注册表"：只登记 id→provider/model，档位排序由 tiers 决定

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelSelector.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/ModelSelector.java
@@ -85,15 +85,16 @@ public class ModelSelector {
     }
 
     public List<ModelTarget> selectEmbeddingCandidates() {
-        return selectCandidates(properties.getEmbedding());
+        return selectCandidates(properties.getEmbedding(), null);
     }
 
     public List<ModelTarget> selectRerankCandidates() {
-        return selectCandidates(properties.getRerank());
+        return selectCandidates(properties.getRerank(), null);
     }
 
     public List<ModelTarget> selectVlmCandidates() {
-        return selectCandidates(properties.getVlm());
+        AIModelProperties.ModelGroup group = properties.getVlm();
+        return selectCandidates(group, group == null ? null : group.getTimeoutMs());
     }
 
     // ==================== chat：档位机制 ====================
@@ -185,13 +186,13 @@ public class ModelSelector {
 
     // ==================== embedding/rerank/vlm：defaultModel + priority ====================
 
-    private List<ModelTarget> selectCandidates(AIModelProperties.ModelGroup group) {
+    private List<ModelTarget> selectCandidates(AIModelProperties.ModelGroup group, Long timeoutMs) {
         if (group == null || group.getCandidates() == null) {
             return List.of();
         }
         List<AIModelProperties.ModelCandidate> orderedCandidates =
                 filterAndSortCandidates(group.getCandidates(), group.getDefaultModel());
-        return buildAvailableTargets(orderedCandidates);
+        return buildAvailableTargets(orderedCandidates, timeoutMs);
     }
 
     /**
@@ -211,12 +212,11 @@ public class ModelSelector {
                 .collect(Collectors.toList());
     }
 
-    private List<ModelTarget> buildAvailableTargets(List<AIModelProperties.ModelCandidate> candidates) {
+    private List<ModelTarget> buildAvailableTargets(List<AIModelProperties.ModelCandidate> candidates, Long timeoutMs) {
         Map<String, AIModelProperties.ProviderConfig> providers = properties.getProviders();
 
-        // embedding/rerank/vlm 无档位预算，超时走 HTTP 客户端默认
         return candidates.stream()
-                .map(candidate -> buildModelTarget(candidate, providers, null))
+                .map(candidate -> buildModelTarget(candidate, providers, timeoutMs))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/VlmConfigValidator.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/model/VlmConfigValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.model;
+
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * VLM 配置启动期校验器
+ */
+@Component
+@RequiredArgsConstructor
+public class VlmConfigValidator implements InitializingBean {
+
+    private final AIModelProperties properties;
+
+    @Override
+    public void afterPropertiesSet() {
+        AIModelProperties.ModelGroup group = properties.getVlm();
+        if (group == null || group.getCandidates() == null || group.getCandidates().isEmpty()) {
+            return;
+        }
+
+        Long timeoutMs = group.getTimeoutMs();
+        if (timeoutMs != null && timeoutMs <= 0) {
+            throw new IllegalStateException("VLM 配置校验失败: ai.vlm.timeout-ms 必须为正数");
+        }
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/vlm/RoutingVlmService.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/vlm/RoutingVlmService.java
@@ -41,6 +41,9 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 路由式 VLM 服务实现类
@@ -58,6 +61,7 @@ public class RoutingVlmService implements VlmService {
 
     private final ModelSelector selector;
     private final OkHttpClient syncHttpClient;
+    private final Map<Long, OkHttpClient> syncClientByTimeout = new ConcurrentHashMap<>();
 
     public RoutingVlmService(ModelSelector selector,
                              @Qualifier("syncHttpClient") OkHttpClient syncHttpClient) {
@@ -82,7 +86,7 @@ public class RoutingVlmService implements VlmService {
                 .build();
 
         JsonObject respJson;
-        try (Response response = syncHttpClient.newCall(request).execute()) {
+        try (Response response = resolveSyncClient(target.timeoutMs()).newCall(request).execute()) {
             if (!response.isSuccessful()) {
                 String body = HttpResponseHelper.readBody(response.body());
                 log.warn("VLM 请求失败: status={}, body={}", response.code(), body);
@@ -99,6 +103,19 @@ public class RoutingVlmService implements VlmService {
         }
 
         return extractContent(respJson);
+    }
+
+    /**
+     * VLM 推理通常显著慢于普通同步请求，按模型组预算覆盖 read/call 超时。
+     */
+    private OkHttpClient resolveSyncClient(Long timeoutMs) {
+        if (timeoutMs == null) {
+            return syncHttpClient;
+        }
+        return syncClientByTimeout.computeIfAbsent(timeoutMs, ms -> syncHttpClient.newBuilder()
+                .readTimeout(ms, TimeUnit.MILLISECONDS)
+                .callTimeout(ms, TimeUnit.MILLISECONDS)
+                .build());
     }
 
     private ModelTarget resolveTarget() {

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/RAGSettingsController.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/RAGSettingsController.java
@@ -240,6 +240,7 @@ public class RAGSettingsController {
         }
         return AISettings.ModelGroup.builder()
                 .defaultModel(group.getDefaultModel())
+                .timeoutMs(group.getTimeoutMs())
                 .candidates(group.getCandidates() == null
                         ? null
                         : group.getCandidates().stream()

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/vo/SystemSettingsVO.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/controller/vo/SystemSettingsVO.java
@@ -265,6 +265,7 @@ public class SystemSettingsVO {
              * defaultModel 供 embedding/rerank/vlm 使用；chat 组走档位（tiers）字段
              */
             private String defaultModel;
+            private Long timeoutMs;
             private List<ModelCandidate> candidates;
             private String defaultTier;
             private String deepThinkingTier;

--- a/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/ModelSelectorTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/ModelSelectorTest.java
@@ -161,4 +161,18 @@ class ModelSelectorTest {
         List<ModelTarget> targets = selector.selectChatCandidates(false);
         assertEquals(List.of("qwen3-local", "gpt-5.4"), ids(targets));
     }
+
+    @Test
+    void vlm_候选携带模型组超时预算() {
+        AIModelProperties.ModelGroup vlm = new AIModelProperties.ModelGroup();
+        vlm.setDefaultModel("qwen-vl-max");
+        vlm.setTimeoutMs(120000L);
+        vlm.setCandidates(List.of(cand("qwen-vl-max", "bailian", "qwen-vl-max", false)));
+        properties.setVlm(vlm);
+
+        List<ModelTarget> targets = selector.selectVlmCandidates();
+
+        assertEquals(1, targets.size());
+        assertEquals(120000L, targets.get(0).timeoutMs());
+    }
 }

--- a/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/VlmConfigValidatorTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/infra/model/VlmConfigValidatorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.model;
+
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class VlmConfigValidatorTest {
+
+    @Test
+    void 未配置候选时跳过校验() {
+        assertDoesNotThrow(() -> validate(new AIModelProperties()));
+    }
+
+    @Test
+    void 正数超时校验通过() {
+        AIModelProperties properties = configuredProperties();
+        properties.getVlm().setTimeoutMs(120000L);
+
+        assertDoesNotThrow(() -> validate(properties));
+    }
+
+    @Test
+    void 未配置超时时兼容全局客户端() {
+        assertDoesNotThrow(() -> validate(configuredProperties()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void 非正数超时时校验失败(long timeoutMs) {
+        AIModelProperties properties = configuredProperties();
+        properties.getVlm().setTimeoutMs(timeoutMs);
+
+        assertThrows(IllegalStateException.class, () -> validate(properties));
+    }
+
+    private static AIModelProperties configuredProperties() {
+        AIModelProperties properties = new AIModelProperties();
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId("qwen-vl-max");
+        properties.getVlm().setCandidates(List.of(candidate));
+        return properties;
+    }
+
+    private static void validate(AIModelProperties properties) {
+        new VlmConfigValidator(properties).afterPropertiesSet();
+    }
+}

--- a/rag/src/test/java/com/nageoffer/ai/ragent/infra/vlm/RoutingVlmServiceTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/infra/vlm/RoutingVlmServiceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.vlm;
+
+import com.nageoffer.ai.ragent.infra.config.AIModelProperties;
+import com.nageoffer.ai.ragent.infra.http.ModelClientException;
+import com.nageoffer.ai.ragent.infra.model.ModelSelector;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoutingVlmServiceTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.close();
+    }
+
+    @Test
+    void configuredTimeoutShouldOverrideShortGlobalClientTimeout() {
+        server.enqueue(new MockResponse.Builder()
+                .setHeader("Content-Type", "application/json")
+                .body("{\"choices\":[{\"message\":{\"content\":\"图片描述\"}}]}")
+                .bodyDelay(150, TimeUnit.MILLISECONDS)
+                .build());
+
+        AIModelProperties.ProviderConfig provider = new AIModelProperties.ProviderConfig();
+        provider.setUrl(server.url("/").toString());
+        provider.setApiKey("test-key");
+        provider.setEndpoints(Map.of("chat", "v1/chat/completions"));
+
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId("qwen-vl-max");
+        candidate.setProvider("bailian");
+        candidate.setModel("qwen-vl-max");
+
+        ModelSelector selector = mock(ModelSelector.class);
+        when(selector.selectVlmCandidates())
+                .thenReturn(List.of(new ModelTarget("qwen-vl-max", candidate, provider, 500L)));
+
+        OkHttpClient shortTimeoutClient = new OkHttpClient.Builder()
+                .readTimeout(Duration.ofMillis(50))
+                .callTimeout(Duration.ofMillis(50))
+                .build();
+        RoutingVlmService service = new RoutingVlmService(selector, shortTimeoutClient);
+
+        String result = service.describeImage(new byte[]{1, 2, 3}, "image/png", "描述图片", 100);
+
+        assertEquals("图片描述", result);
+    }
+
+    @Test
+    void missingTimeoutShouldUseGlobalClientTimeout() {
+        server.enqueue(new MockResponse.Builder()
+                .setHeader("Content-Type", "application/json")
+                .body("{\"choices\":[{\"message\":{\"content\":\"图片描述\"}}]}")
+                .bodyDelay(150, TimeUnit.MILLISECONDS)
+                .build());
+
+        AIModelProperties.ProviderConfig provider = new AIModelProperties.ProviderConfig();
+        provider.setUrl(server.url("/").toString());
+        provider.setApiKey("test-key");
+        provider.setEndpoints(Map.of("chat", "v1/chat/completions"));
+
+        AIModelProperties.ModelCandidate candidate = new AIModelProperties.ModelCandidate();
+        candidate.setId("qwen-vl-max");
+        candidate.setProvider("bailian");
+        candidate.setModel("qwen-vl-max");
+
+        ModelSelector selector = mock(ModelSelector.class);
+        when(selector.selectVlmCandidates())
+                .thenReturn(List.of(new ModelTarget("qwen-vl-max", candidate, provider, null)));
+
+        OkHttpClient shortTimeoutClient = new OkHttpClient.Builder()
+                .readTimeout(Duration.ofMillis(50))
+                .callTimeout(Duration.ofMillis(50))
+                .build();
+        RoutingVlmService service = new RoutingVlmService(selector, shortTimeoutClient);
+
+        assertThrows(ModelClientException.class,
+                () -> service.describeImage(new byte[]{1, 2, 3}, "image/png", "描述图片", 100));
+    }
+}


### PR DESCRIPTION
# feat(vlm): 支持单独配置请求超时时间

## 背景

https://github.com/nageoffer/ragent/issues/107

知识库上传图片后会调用 VLM 生成图片描述。原实现直接复用全局 `syncHttpClient`，其读取超时为 30 秒。当 VLM 正常响应时间超过该限制时，图片分块任务会因 `timeout` 失败。

## 修改内容

- 增加 `ai.vlm.timeout-ms` 配置，默认值为 `120000` 毫秒。
- 将 VLM 模型组的超时预算传递到 `ModelTarget`。
- 基于全局 `syncHttpClient` 派生 VLM 客户端，仅覆盖 `readTimeout` 和 `callTimeout`，保留原有连接、写入及重试配置。
- 未配置 `timeout-ms` 时继续使用全局同步 HTTP 客户端，保持向后兼容。
- 显式配置为 `0` 或负数时，在启动阶段校验失败。
- 在系统设置接口和管理端 VLM 卡片中展示当前超时时间。
- 增加候选选择、配置校验和实际请求超时行为测试。

## 配置示例

```yaml
ai:
  vlm:
    timeout-ms: 120000
```

## 兼容性影响

- 仅影响 VLM 同步请求。
- 未配置该参数时，继续沿用原有 `syncHttpClient` 超时配置。

## 验证

### 相关后端测试

```bash
./mvnw -pl rag -am \
  -Dtest=VlmConfigValidatorTest,ModelSelectorTest,RoutingVlmServiceTest,RagentCoreApplicationTests \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

结果：18 个测试全部通过。

### 前端类型检查与生产构建

```bash
cd frontend
npx tsc --noEmit
VITE_API_BASE_URL=/api/ragent npm run build
```

结果：类型检查和生产构建通过。

## 截图

系统设置页面的 VLM 卡片会展示当前配置的超时时间。此处设置为`timeout-ms: 120000` 

<img width="1800" height="1042" alt="image" src="https://github.com/user-attachments/assets/05d2ea85-f70e-41b0-9200-679c4b73e10d" />
