### PR TITLE
fix(rag): MCP 工具调用增加超时，避免检索线程卡死

### DIFF
--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/RAGConfigProperties.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/config/RAGConfigProperties.java
@@ -79,4 +79,14 @@ public class RAGConfigProperties {
      */
     @Value("${rag.citation.enabled:false}")
     private Boolean citationEnabled;
+
+    /**
+     * MCP 工具调用超时时间（秒）
+     * <p>
+     * 控制检索链路中单个 MCP 工具调用的最长等待时间，超时后该工具按失败处理，
+     * 避免远端 MCP Server 或网络异常导致检索线程永久阻塞
+     * 默认值：{@code 60}
+     */
+    @Value("${rag.mcp.tool-timeout-seconds:60}")
+    private Long mcpToolTimeoutSeconds;
 }

--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/core/retrieval/RetrievalEngine.java
@@ -21,6 +21,7 @@ import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.util.StrUtil;
 import com.nageoffer.ai.ragent.framework.convention.RetrievedChunk;
 import com.nageoffer.ai.ragent.framework.trace.RagTraceNode;
+import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
 import com.nageoffer.ai.ragent.rag.config.SearchChannelProperties;
 import com.nageoffer.ai.ragent.rag.core.intent.IntentNode;
 import com.nageoffer.ai.ragent.rag.core.intent.NodeScore;
@@ -52,6 +53,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.nageoffer.ai.ragent.rag.constant.RAGConstant.CONTEXT_FORMAT_PATH;
@@ -74,6 +76,7 @@ public class RetrievalEngine {
     private final MultiChannelRetrievalEngine multiChannelRetrievalEngine;
     private final Executor ragContextExecutor;
     private final Executor mcpBatchExecutor;
+    private final RAGConfigProperties ragConfigProperties;
 
     /**
      * 检索方法：根据子问题意图列表执行检索，整合知识库和MCP工具的结果
@@ -232,23 +235,34 @@ public class RetrievalEngine {
             return Map.of();
         }
 
+        long mcpTimeoutMillis = TimeUnit.SECONDS.toMillis(ragConfigProperties.getMcpToolTimeoutSeconds());
         List<CompletableFuture<ToolOutput>> futures = mcpIntentScores.stream()
-                .map(ns -> CompletableFuture.supplyAsync(
-                        () -> {
-                            String toolId = ns.getNode().getMcpToolId();
-                            try {
-                                CallToolResult result = executeSingleMcpTool(question, ns.getNode());
-                                return result == null ? null : new ToolOutput(toolId, result);
-                            } catch (Exception e) {
-                                log.error("MCP 工具调用异常, toolId: {}", toolId, e);
-                                return new ToolOutput(toolId, CallToolResult.builder()
-                                        .content(List.of(new TextContent("工具调用异常: " + e.getMessage())))
-                                        .isError(true)
-                                        .build());
-                            }
-                        },
-                        mcpBatchExecutor
-                ))
+                .map(ns -> {
+                    String toolId = ns.getNode().getMcpToolId();
+                    return CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    CallToolResult result = executeSingleMcpTool(question, ns.getNode());
+                                    return result == null ? null : new ToolOutput(toolId, result);
+                                } catch (Exception e) {
+                                    log.error("MCP 工具调用异常, toolId: {}", toolId, e);
+                                    return new ToolOutput(toolId, CallToolResult.builder()
+                                            .content(List.of(new TextContent("工具调用异常: " + e.getMessage())))
+                                            .isError(true)
+                                            .build());
+                                }
+                            },
+                            mcpBatchExecutor
+                    )
+                    .orTimeout(mcpTimeoutMillis, TimeUnit.MILLISECONDS)
+                    .exceptionally(e -> {
+                        log.warn("MCP 工具调用超时, toolId: {}", toolId, e);
+                        return new ToolOutput(toolId, CallToolResult.builder()
+                                .content(List.of(new TextContent("工具调用超时: " + ragConfigProperties.getMcpToolTimeoutSeconds() + "s")))
+                                .isError(true)
+                                .build());
+                    });
+                })
                 .toList();
 
         return futures.stream()


### PR DESCRIPTION
修复 #121

## 问题
executeMcpTools 用 CompletableFuture::join 收集 MCP 工具结果，没有超时。远端 MCP Server 或网络一直不返回时，join 会一直等待，检索线程被卡住。

## 改动
- 新增配置 rag.mcp.tool-timeout-seconds，默认 60 秒
- 每个工具调用加 orTimeout + exceptionally，超时按工具调用失败返回错误结果，不再阻塞检索链路

## 验证
- 本地语法检查通过；模块级编译由 CI 覆盖（本地构建被框架模块的 RocketMQ 镜像问题阻塞，与本次改动无关）