### PR TITLE
fix(rewrite): honor should_split in rewrite responses

### DIFF
--- a/rag/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
+++ b/rag/src/main/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteService.java
@@ -181,7 +181,13 @@ public class MultiQuestionRewriteService implements QueryRewriteService {
             if (StrUtil.isBlank(rewrite)) {
                 return null;
             }
-            if (CollUtil.isEmpty(subs)) {
+            JsonElement shouldSplit = obj.get("should_split");
+            if (shouldSplit != null
+                    && shouldSplit.isJsonPrimitive()
+                    && shouldSplit.getAsJsonPrimitive().isBoolean()
+                    && !shouldSplit.getAsBoolean()) {
+                subs = List.of(rewrite);
+            } else if (CollUtil.isEmpty(subs)) {
                 subs = List.of(rewrite);
             }
             return new RewriteResult(rewrite, subs);

--- a/rag/src/test/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteServiceTest.java
+++ b/rag/src/test/java/com/nageoffer/ai/ragent/rag/core/rewrite/MultiQuestionRewriteServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.rag.core.rewrite;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.infra.chat.LLMService;
+import com.nageoffer.ai.ragent.infra.enums.Tier;
+import com.nageoffer.ai.ragent.rag.config.RAGConfigProperties;
+import com.nageoffer.ai.ragent.rag.core.prompt.PromptTemplateLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MultiQuestionRewriteServiceTest {
+
+    private static final String QUESTION = "微服务架构和单体架构有什么区别";
+
+    private LLMService llmService;
+    private MultiQuestionRewriteService service;
+
+    @BeforeEach
+    void setUp() {
+        llmService = mock(LLMService.class);
+        RAGConfigProperties ragConfigProperties = mock(RAGConfigProperties.class);
+        QueryTermMappingService queryTermMappingService = mock(QueryTermMappingService.class);
+        PromptTemplateLoader promptTemplateLoader = mock(PromptTemplateLoader.class);
+
+        when(ragConfigProperties.getQueryRewriteEnabled()).thenReturn(true);
+        when(queryTermMappingService.normalize(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(promptTemplateLoader.load(anyString())).thenReturn("rewrite prompt");
+
+        service = new MultiQuestionRewriteService(
+                llmService, ragConfigProperties, queryTermMappingService, promptTemplateLoader);
+    }
+
+    @Test
+    void shouldUseRewriteOnlyWhenShouldSplitIsFalse() {
+        RewriteResult result = rewriteWithResponse("""
+                {
+                  "rewrite": "微服务架构和单体架构有什么区别",
+                  "should_split": false,
+                  "sub_questions": ["什么是微服务架构", "什么是单体架构"]
+                }
+                """);
+
+        assertEquals(QUESTION, result.rewrittenQuestion());
+        assertEquals(List.of(QUESTION), result.subQuestions());
+    }
+
+    @Test
+    void shouldUseCleanedSubQuestionsWhenShouldSplitIsTrue() {
+        RewriteResult result = rewriteWithResponse("""
+                {
+                  "rewrite": "微服务架构和单体架构有什么区别",
+                  "should_split": true,
+                  "sub_questions": [" 什么是微服务架构 ", "", 42, "什么是单体架构"]
+                }
+                """);
+
+        assertEquals(List.of("什么是微服务架构", "什么是单体架构"), result.subQuestions());
+    }
+
+    @Test
+    void shouldUseRewriteWhenShouldSplitIsTrueButSubQuestionsAreEmpty() {
+        RewriteResult result = rewriteWithResponse("""
+                {
+                  "rewrite": "微服务架构和单体架构有什么区别",
+                  "should_split": true,
+                  "sub_questions": ["  ", 42]
+                }
+                """);
+
+        assertEquals(List.of(QUESTION), result.subQuestions());
+    }
+
+    @Test
+    void shouldKeepExistingBehaviorWhenShouldSplitIsMissing() {
+        RewriteResult result = rewriteWithResponse("""
+                {
+                  "rewrite": "微服务架构和单体架构有什么区别",
+                  "sub_questions": ["什么是微服务架构", "什么是单体架构"]
+                }
+                """);
+
+        assertEquals(List.of("什么是微服务架构", "什么是单体架构"), result.subQuestions());
+    }
+
+    @Test
+    void shouldKeepExistingBehaviorWhenShouldSplitHasWrongType() {
+        RewriteResult result = rewriteWithResponse("""
+                {
+                  "rewrite": "微服务架构和单体架构有什么区别",
+                  "should_split": "false",
+                  "sub_questions": ["什么是微服务架构", "什么是单体架构"]
+                }
+                """);
+
+        assertEquals(List.of("什么是微服务架构", "什么是单体架构"), result.subQuestions());
+    }
+
+    private RewriteResult rewriteWithResponse(String response) {
+        when(llmService.chat(any(ChatRequest.class), eq(Tier.FAST))).thenReturn(response);
+        return service.rewriteWithSplit(QUESTION);
+    }
+}


### PR DESCRIPTION
## 问题

查询改写提示词要求 LLM 返回 `rewrite`、`should_split` 和 `sub_questions`，但解析器此前只读取了 `rewrite` 和 `sub_questions`。

当模型返回 `should_split=false` 但同时给出多个子问题时，现有实现仍会触发多路意图识别和检索，造成冗余检索或语义偏移。

## 修改

- 当 `should_split` 是布尔值 `false` 时，仅使用 `rewrite` 作为查询
- 当 `should_split=true` 时，继续使用清理后的非空子问题
- 子问题为空时回退到单个 `rewrite`
- 字段缺失或类型错误时保持现有兼容行为
- 增加不依赖真实 LLM 的单元测试，覆盖 5 个解析场景

本次不处理子问题去重，保持修改范围最小。

## 测试

`./mvnw.cmd -pl rag -am "-Dtest=MultiQuestionRewriteServiceTest,StreamChatPipelineTest,KnowledgeSearchFacadeTest" "-Dsurefire.failIfNoSpecifiedTests=false" test`

Tests run: 10, Failures: 0, Errors: 0, Skipped: 0

Fixes #124