### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -217,6 +217,12 @@ ai:
       endpoints:
         chat: /v1/chat/completions
         embedding: /v1/embeddings
+    litellm:
+      url: ${LITELLM_BASE_URL:http://localhost:4000}
+      api-key: ${LITELLM_API_KEY:}
+      endpoints:
+        chat: /v1/chat/completions
+        embedding: /v1/embeddings
 
   selection:
     failure-threshold: 2

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/LiteLLMChatClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/chat/LiteLLMChatClient.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.chat;
+
+import com.nageoffer.ai.ragent.framework.convention.ChatRequest;
+import com.nageoffer.ai.ragent.framework.trace.RagTraceNode;
+import com.nageoffer.ai.ragent.infra.enums.ModelProvider;
+import com.nageoffer.ai.ragent.infra.model.ModelTarget;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * LiteLLM chat client.
+ *
+ * <p>LiteLLM Proxy exposes an OpenAI-compatible Chat Completions API, so this
+ * client reuses the shared OpenAI-style transport unchanged. Pointing the
+ * provider at a LiteLLM gateway lets RAgent reach 100+ upstream providers
+ * (OpenAI, Anthropic, Bedrock, Vertex AI, Azure, and more) through a single
+ * endpoint with centralized keys and routing.
+ */
+@Slf4j
+@Service
+public class LiteLLMChatClient extends AbstractOpenAIStyleChatClient {
+
+    @Override
+    public String provider() {
+        return ModelProvider.LITE_LLM.getId();
+    }
+
+    @Override
+    @RagTraceNode(name = "litellm-chat", type = "LLM_PROVIDER")
+    public String chat(ChatRequest request, ModelTarget target) {
+        return doChat(request, target);
+    }
+
+    @Override
+    public StreamCancellationHandle streamChat(ChatRequest request, StreamCallback callback, ModelTarget target) {
+        return doStreamChat(request, callback, target);
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/embedding/LiteLLMEmbeddingClient.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/embedding/LiteLLMEmbeddingClient.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.embedding;
+
+import com.nageoffer.ai.ragent.infra.enums.ModelProvider;
+import okhttp3.OkHttpClient;
+import org.springframework.stereotype.Service;
+
+/**
+ * LiteLLM embedding client.
+ *
+ * <p>LiteLLM Proxy exposes an OpenAI-compatible {@code /embeddings} endpoint,
+ * so this client reuses the shared OpenAI-style embedding transport unchanged.
+ */
+@Service
+public class LiteLLMEmbeddingClient extends AbstractOpenAIStyleEmbeddingClient {
+
+    public LiteLLMEmbeddingClient(OkHttpClient syncHttpClient) {
+        super(syncHttpClient);
+    }
+
+    @Override
+    public String provider() {
+        return ModelProvider.LITE_LLM.getId();
+    }
+
+    @Override
+    protected int maxBatchSize() {
+        return 32;
+    }
+}

--- a/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/enums/ModelProvider.java
+++ b/infra-ai/src/main/java/com/nageoffer/ai/ragent/infra/enums/ModelProvider.java
@@ -49,6 +49,11 @@ public enum ModelProvider {
     AI_HUB_MIX("aihubmix"),
 
     /**
+     * LiteLLM gateway (OpenAI-compatible proxy for 100+ providers)
+     */
+    LITE_LLM("litellm"),
+
+    /**
      * 空实现，用于测试或占位
      */
     NOOP("noop");

--- a/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/chat/LiteLLMProviderTest.java
+++ b/infra-ai/src/test/java/com/nageoffer/ai/ragent/infra/chat/LiteLLMProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nageoffer.ai.ragent.infra.chat;
+
+import com.nageoffer.ai.ragent.infra.embedding.LiteLLMEmbeddingClient;
+import com.nageoffer.ai.ragent.infra.enums.ModelProvider;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LiteLLMProviderTest {
+
+    @Test
+    void litellmProviderIdIsStable() {
+        assertEquals("litellm", ModelProvider.LITE_LLM.getId());
+        assertTrue(ModelProvider.LITE_LLM.matches("LiteLLM"));
+    }
+
+    @Test
+    void chatAndEmbeddingClientsBindToLitellmProvider() {
+        assertEquals(ModelProvider.LITE_LLM.getId(), new LiteLLMChatClient().provider());
+        assertEquals(ModelProvider.LITE_LLM.getId(), new LiteLLMEmbeddingClient(new OkHttpClient()).provider());
+    }
+}


### PR DESCRIPTION
## Summary

Adds **LiteLLM** as a first-class model provider (chat + embedding). LiteLLM Proxy exposes an OpenAI-compatible Chat Completions and Embeddings API, so RAgent users can point a single provider at a LiteLLM gateway and reach 100+ upstream providers (OpenAI, Anthropic, Bedrock, Vertex AI, Azure, and more) through one endpoint, with keys, budgets, and fallbacks managed centrally in the gateway.

## Why it fits cleanly

- `RoutingLLMService` / `RoutingEmbeddingService` build their provider map from every `ChatClient` / `EmbeddingClient` bean keyed on `provider()`. A new `@Service` whose `provider()` returns `litellm` self-registers with zero routing changes.
- LiteLLM Proxy speaks the OpenAI wire format, so both clients extend the shared `AbstractOpenAIStyleChatClient` / `AbstractOpenAIStyleEmbeddingClient` and reuse the tested transport unchanged (same as `aihubmix` and `siliconflow`).
- Base URL, key, and endpoints come from `AIModelProperties` config, so no hardcoding.

## Changes

- `infra-ai/.../infra/enums/ModelProvider.java`: add `LITE_LLM("litellm")`.
- `infra-ai/.../infra/chat/LiteLLMChatClient.java`: new `@Service` chat client (mirrors `AIHubMixChatClient`).
- `infra-ai/.../infra/embedding/LiteLLMEmbeddingClient.java`: new `@Service` embedding client (mirrors `AIHubMixEmbeddingClient`).
- `bootstrap/src/main/resources/application.yaml`: add a `litellm` provider block under `ai.providers` (defaults to `http://localhost:4000`, overridable via `LITELLM_BASE_URL` / `LITELLM_API_KEY`). No changes to existing tiers or candidates, so default routing is untouched.
- `infra-ai/src/test/.../infra/chat/LiteLLMProviderTest.java`: unit test.

Additive only. No existing provider or routing code is modified.

## Tests

**1. Build + unit test (`mvn -pl infra-ai -am test -Dtest=LiteLLMProviderTest`, JDK 21):**
```
[INFO] Running com.nageoffer.ai.ragent.infra.chat.LiteLLMProviderTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s -- in com.nageoffer.ai.ragent.infra.chat.LiteLLMProviderTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**2. Live end-to-end through a LiteLLM Proxy** (the OpenAI-compatible endpoints both clients call), routing through two different upstreams:

Model chat via `/v1/chat/completions` (`gpt-4.1-mini` through LiteLLM):
```
$ curl -s $LITELLM_BASE_URL/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: RAGENT_LITELLM_OK"}],"stream":false,"temperature":0}'
content:        RAGENT_LITELLM_OK
finish_reason:  stop
usage:          {prompt_tokens: 18, completion_tokens: 7, total_tokens: 25}
```

Streaming via SSE (`gemini-2.5-flash` through LiteLLM, as `doStreamChat` consumes):
```
data: {"object":"chat.completion.chunk","model":"gemini-2.5-flash","choices":[{"delta":{"role":"assistant","content":"Hi"}}]}
data: {"object":"chat.completion.chunk","model":"gemini-2.5-flash","choices":[{"delta":{},"finish_reason":"stop"}]}
data: [DONE]
```

These are the exact OpenAI wire shapes that `AbstractOpenAIStyleChatClient` (`OpenAIStyleSseParser`) produces and parses, confirming both non-streaming and streaming work through LiteLLM across different upstream providers.

The embedding client reuses the same tested `AbstractOpenAIStyleEmbeddingClient` transport and calls the standard OpenAI-compatible `/v1/embeddings` endpoint; my local proxy only had chat deployments configured, so I verified the endpoint is reachable and OpenAI-shaped but did not capture a full vector here.

## Example usage

```yaml
ai:
  providers:
    litellm:
      url: ${LITELLM_BASE_URL:http://localhost:4000}
      api-key: ${LITELLM_API_KEY:}
      endpoints:
        chat: /v1/chat/completions
        embedding: /v1/embeddings
  chat:
    candidates:
      - id: gpt-5-via-litellm
        provider: litellm
        model: gpt-5.4
```

Run a LiteLLM proxy (`litellm --config config.yaml`, default `http://localhost:4000`), add a candidate with `provider: litellm`, and route to any model the gateway exposes.